### PR TITLE
Export formats: JPEG/WebP, quality control, and font-embedding hardening

### DIFF
--- a/src/components/open-screenshot-generator/ExportDialog.tsx
+++ b/src/components/open-screenshot-generator/ExportDialog.tsx
@@ -13,12 +13,18 @@ import {
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Slider } from "@/components/ui/slider";
 import type { Size } from '@/types/artboard';
 import {
   APP_STORE_FORMAT_IDS,
   DEVICE_FORMAT_PRESETS,
   type DeviceFormat,
 } from '@/lib/deviceRegistry';
+
+// Image formats the screenshot export can produce. Every file in a run uses
+// the same one.
+export type ImageFormat = 'png' | 'jpeg' | 'webp';
 
 export interface ExportSelection {
   // Export the artboards exactly as they are on the canvas.
@@ -31,6 +37,11 @@ export interface ExportSelection {
   // instead of the whole project. Off unless the dialog was opened from an
   // artboard's own toolbar.
   currentArtboardOnly: boolean;
+  // Image format for every file this run produces. JPEG and WebP have no
+  // alpha channel, so transparency is flattened onto the artboard background.
+  format: ImageFormat;
+  // JPEG/WebP compression quality on a 0..1 scale (ignored for PNG).
+  quality: number;
 }
 
 // Shared with AppPreviewExportDialog (the video projects' own dialog), which
@@ -100,6 +111,8 @@ export function ExportDialog({
   const [asIs, setAsIs] = useState(true);
   const [generateFormats, setGenerateFormats] = useState<DeviceFormat[]>([]);
   const [currentArtboardOnly, setCurrentArtboardOnly] = useState(false);
+  const [format, setFormat] = useState<ImageFormat>('png');
+  const [quality, setQuality] = useState(0.92);
 
   const canScopeToArtboard = !!activeArtboard;
   // Everything below describes what the export produces, so it has to follow
@@ -114,6 +127,8 @@ export function ExportDialog({
       setAsIs(true);
       setGenerateFormats([]);
       setCurrentArtboardOnly(defaultCurrentArtboardOnly);
+      setFormat('png');
+      setQuality(0.92);
     }
   }, [isOpen, defaultCurrentArtboardOnly]);
 
@@ -168,9 +183,10 @@ export function ExportDialog({
         <DialogHeader>
           <DialogTitle>Export Screenshots</DialogTitle>
           <DialogDescription>
-            Download the artboards as PNGs, and optionally generate the App
-            Store sizes this project is missing. Generated formats convert the
-            canvas and mockups on the fly — your project stays untouched.
+            Download the artboards as PNG, JPEG or WebP images, and optionally
+            generate the App Store sizes this project is missing. Generated
+            formats convert the canvas and mockups on the fly — your project
+            stays untouched.
           </DialogDescription>
         </DialogHeader>
 
@@ -206,6 +222,68 @@ export function ExportDialog({
               </Label>
               <p className="text-xs text-muted-foreground">{scopeDescription}</p>
             </div>
+          </div>
+
+          <div>
+            <p className="text-sm font-medium mb-0.5">Image format</p>
+            <p className="text-xs text-muted-foreground mb-3">
+              Applied to the current canvas export and every generated App
+              Store format. JPEG and WebP flatten transparency onto the
+              artboard background.
+            </p>
+            <RadioGroup
+              value={format}
+              onValueChange={(v) => setFormat(v as ImageFormat)}
+              className="grid gap-3"
+            >
+              <div className="flex items-start space-x-2">
+                <RadioGroupItem value="png" id="format-png" />
+                <div className="grid gap-0.5 leading-none">
+                  <Label htmlFor="format-png">PNG</Label>
+                  <p className="text-xs text-muted-foreground">
+                    Lossless, keeps transparency. Largest file size.
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-start space-x-2">
+                <RadioGroupItem value="jpeg" id="format-jpeg" />
+                <div className="grid gap-0.5 leading-none">
+                  <Label htmlFor="format-jpeg">JPEG</Label>
+                  <p className="text-xs text-muted-foreground">
+                    Small files, no transparency. Best for photos.
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-start space-x-2">
+                <RadioGroupItem value="webp" id="format-webp" />
+                <div className="grid gap-0.5 leading-none">
+                  <Label htmlFor="format-webp">WebP</Label>
+                  <p className="text-xs text-muted-foreground">
+                    Small files with good quality. Supported in all modern
+                    browsers.
+                  </p>
+                </div>
+              </div>
+            </RadioGroup>
+
+            {format !== 'png' && (
+              <div className="grid gap-2 mt-3">
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="export-quality">Quality</Label>
+                  <span className="text-xs text-muted-foreground">
+                    {Math.round(quality * 100)}%
+                  </span>
+                </div>
+                <Slider
+                  id="export-quality"
+                  min={0.5}
+                  max={1}
+                  step={0.01}
+                  value={[quality]}
+                  onValueChange={(v) => setQuality(v[0])}
+                />
+              </div>
+            )}
           </div>
 
           <div>
@@ -251,7 +329,13 @@ export function ExportDialog({
           </DialogClose>
           <Button
             onClick={() =>
-              onConfirmExport({ asIs, generateFormats, currentArtboardOnly: scopedToArtboard })
+              onConfirmExport({
+                asIs,
+                generateFormats,
+                currentArtboardOnly: scopedToArtboard,
+                format,
+                quality,
+              })
             }
             disabled={nothingSelected}
           >

--- a/src/components/open-screenshot-generator/OpenScreenshotGeneratorLayout.tsx
+++ b/src/components/open-screenshot-generator/OpenScreenshotGeneratorLayout.tsx
@@ -1419,27 +1419,45 @@ export function OpenScreenshotGeneratorLayout() {
         continue;
       }
 
+      let imageDataUrl: string | null = null;
+      let fontsSkipped = false;
       try {
         // Store original transform and dimensions
         const originalTransform = artboardElement.style.transform;
         const originalWidth = artboardElement.style.width;
         const originalHeight = artboardElement.style.height;
 
-        // Capture the artboard at exact specified dimensions
+        // Capture the artboard at exact specified dimensions. The scale
+        // transform is stripped for capture, and the original styling is
+        // restored in the finally below no matter which path the capture
+        // takes (including a font-skip retry).
         const { backgroundColor, backgroundImage } = artboardBackground(artboard);
-        const imageDataUrl = await captureArtboardImage(artboardElement, {
+        const captureOptions: ArtboardCaptureOptions = {
           format: image.format,
           quality: image.quality,
           backgroundColor,
           backgroundImage,
           width: artboard.size.width,
           height: artboard.size.height,
-        });
-
-        // Restore original styling after export
-        artboardElement.style.transform = originalTransform;
-        artboardElement.style.width = originalWidth;
-        artboardElement.style.height = originalHeight;
+        };
+        try {
+          artboardElement.style.transform = 'scale(1)';
+          imageDataUrl = await captureArtboardImage(artboardElement, captureOptions);
+        } catch (captureError) {
+          // Retry once without web fonts: a font that fails to embed is the
+          // usual way a capture crashes, and the image is still usable
+          // without it. A second failure propagates to the outer catch.
+          console.warn(`Artboard capture failed for "${artboard.name}", retrying without web fonts.`, captureError);
+          imageDataUrl = await captureArtboardImage(artboardElement, {
+            ...captureOptions,
+            skipFonts: true,
+          });
+          fontsSkipped = true;
+        } finally {
+          artboardElement.style.transform = originalTransform;
+          artboardElement.style.width = originalWidth;
+          artboardElement.style.height = originalHeight;
+        }
 
         // Prefix with the canvas position (zero-padded so 10+ boards sort correctly)
         const canvasIndex = order?.indexById[artboard.id] ?? index + 1;
@@ -1471,6 +1489,13 @@ export function OpenScreenshotGeneratorLayout() {
         // dialog now narrates it live, so the caller summarises at the end
         // instead. A lone file still gets its own toast there.
         saved.push({ filename, path: savedPath || undefined });
+
+        if (fontsSkipped) {
+          toast({
+            title: "Fonts skipped",
+            description: "Web fonts couldn't be embedded; text may render in a fallback font.",
+          });
+        }
 
       } catch (error) {
         console.error("Error exporting artboard:", artboard.name, error);

--- a/src/components/open-screenshot-generator/OpenScreenshotGeneratorLayout.tsx
+++ b/src/components/open-screenshot-generator/OpenScreenshotGeneratorLayout.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useState, useEffect, useLayoutEffect, useCallback, useMemo, useRef, useDeferredValue } from 'react';
-import { toPng } from 'html-to-image';
+import { toPng, toJpeg } from 'html-to-image';
 import { preloadGoogleFonts } from '@/services/fontService';
 import { isTauri, sanitizeFileName, saveBlobToDisk, saveBlobToPath, saveDataUrlToDisk, saveDataUrlToPath, pickExportDirectory, openExternal } from '@/lib/desktop';
 import { analyzeArtboardForVideo, exportArtboardVideo, projectHasVideoContent, type ArtboardVideoInfo } from '@/lib/video/videoExport';
@@ -26,7 +26,7 @@ import { TranslateDialog, getLanguageName } from './TranslateDialog';
 import { translateText, detectLanguage, isTranslationEnabled, AUTO_DETECT } from '@/services/translation';
 import { Logo } from './Logo';
 import type { ArtboardState, ElementType, Point, ShapeType, DeviceType, ArtboardElement, TextElementProps, ShapeElementProps, DeviceFrameElementProps, ImageElementProps, Project, Size } from '@/types/artboard';
-import { ExportDialog, type ExportSelection, type VideoExportRequest, type VideoExportProgress } from './ExportDialog';
+import { ExportDialog, type ExportSelection, type ImageFormat, type VideoExportRequest, type VideoExportProgress } from './ExportDialog';
 import { AppPreviewExportDialog } from './AppPreviewExportDialog';
 import { ExportProgressDialog, type PngExportProgress } from './ExportProgressDialog';
 import { ALL_CANVAS_SIZE_PRESETS } from '@/lib/sizePresets';
@@ -106,6 +106,104 @@ import { cn } from '@/lib/utils';
 // Reduce the margin between artboards
 const ARTBOARD_MARGIN = 15; // Reduced from 30
 const DISPLAY_SCALE_FACTOR = 0.3;
+
+// File extension per export image format. JPEG is ".jpg" so the file opens in
+// every consumer app without guessing.
+const EXPORT_FORMAT_EXTENSION: Record<ImageFormat, string> = {
+  png: '.png',
+  jpeg: '.jpg',
+  webp: '.webp',
+};
+
+// WebP has no html-to-image capture helper, so capture as PNG and re-encode:
+// draw the flattened PNG onto a hidden canvas pre-filled with the artboard's
+// background color (WebP, like JPEG, has no alpha), then encode with the
+// requested quality. Returns a data URL like the html-to-image helpers.
+const pngDataUrlToWebp = (
+  pngDataUrl: string,
+  quality: number,
+  backgroundColor: string
+): Promise<string> =>
+  new Promise((resolve, reject) => {
+    // window.Image, not the next/image component this module imports
+    const image = new window.Image();
+    image.onload = () => {
+      const canvas = document.createElement('canvas');
+      canvas.width = image.naturalWidth;
+      canvas.height = image.naturalHeight;
+      const context = canvas.getContext('2d');
+      if (!context) {
+        reject(new Error('Could not create the WebP encoder canvas.'));
+        return;
+      }
+      context.fillStyle = backgroundColor;
+      context.fillRect(0, 0, canvas.width, canvas.height);
+      context.drawImage(image, 0, 0);
+      canvas.toBlob(
+        (blob) => {
+          if (!blob) {
+            reject(new Error('This browser could not encode WebP.'));
+            return;
+          }
+          const reader = new FileReader();
+          reader.onload = () => resolve(reader.result as string);
+          reader.onerror = () => reject(reader.error ?? new Error('Could not read the WebP image.'));
+          reader.readAsDataURL(blob);
+        },
+        'image/webp',
+        quality
+      );
+    };
+    image.onerror = () => reject(new Error('Could not decode the captured image for WebP.'));
+    image.src = pngDataUrl;
+  });
+
+// Shared capture options for html-to-image, described once so every format
+// branch bakes in the same editor-chrome exclusions and artboard background.
+interface ArtboardCaptureOptions {
+  format: ImageFormat;
+  quality: number;
+  backgroundColor: string;
+  backgroundImage: string;
+  width: number;
+  height: number;
+  skipFonts?: boolean;
+}
+
+const captureArtboardImage = (
+  element: HTMLElement,
+  options: ArtboardCaptureOptions
+): Promise<string> => {
+  const htmlToImageOptions = {
+    width: options.width,
+    height: options.height,
+    backgroundColor: options.backgroundColor,
+    pixelRatio: 1, // Set to 1 to avoid doubling resolution
+    cacheBust: true, // Prevent caching issues
+    skipFonts: options.skipFonts,
+    // Editor chrome (selection outlines, resize handles, upload buttons)
+    // must never be baked into the exported image
+    filter: (node: Node) => {
+      const el = node as HTMLElement;
+      return !(el?.hasAttribute?.('data-export-exclude') || el?.hasAttribute?.('data-interaction-handle'));
+    },
+    style: {
+      width: `${options.width}px`,
+      height: `${options.height}px`,
+      backgroundImage: options.backgroundImage,
+    },
+  };
+  if (options.format === 'jpeg') {
+    return toJpeg(element, { ...htmlToImageOptions, quality: options.quality });
+  }
+  const png = toPng(element, htmlToImageOptions);
+  if (options.format === 'webp') {
+    return png.then((dataUrl) =>
+      pngDataUrlToWebp(dataUrl, options.quality, options.backgroundColor)
+    );
+  }
+  return png;
+};
 
 // Right dock (Properties + Layers) persistence. localStorage so the layout
 // survives an app relaunch, not just a reload.
@@ -1266,7 +1364,7 @@ export function OpenScreenshotGeneratorLayout() {
     }
   };
 
-  // Capture a list of artboards to PNG downloads by grabbing each board's
+  // Capture a list of artboards to image downloads by grabbing each board's
   // live DOM node (matched by artboard id). The list must be what the canvas
   // is currently rendering — for generated formats, handleConfirmExport
   // swaps the converted list in first and restores afterwards.
@@ -1286,7 +1384,10 @@ export function OpenScreenshotGeneratorLayout() {
       // Absolute file number of the first file in this pass, so the counter
       // keeps climbing across the as-is pass and every generated format.
       startIndex: number;
-    }
+    },
+    // Which image format and quality every file in this run should be.
+    // Defaults keep callers that do not care (none today) on PNG.
+    image: { format: ImageFormat; quality: number } = { format: 'png', quality: 0.92 }
   ) => {
     // Array order matches canvas order (calculateArtboardPositions lays boards
     // out left-to-right by index), so the loop index is the on-canvas position.
@@ -1296,8 +1397,8 @@ export function OpenScreenshotGeneratorLayout() {
     const saved: { filename: string; path?: string }[] = [];
 
     for (const [index, artboard] of list.entries()) {
-      // Cancellation lands between files: a half-written PNG helps nobody, and
-      // each capture is short enough that finishing it is barely a wait.
+      // Cancellation lands between files: a half-written image helps nobody,
+      // and each capture is short enough that finishing it is barely a wait.
       if (pngExportCancelRef.current) break;
       progress?.report({
         fileIndex: progress.startIndex + index,
@@ -1323,31 +1424,18 @@ export function OpenScreenshotGeneratorLayout() {
         const originalTransform = artboardElement.style.transform;
         const originalWidth = artboardElement.style.width;
         const originalHeight = artboardElement.style.height;
-        
-        // Remove scale transform for export
-        artboardElement.style.transform = 'scale(1)';
-        
-        // Use html-to-image to capture the artboard at exact specified dimensions
+
+        // Capture the artboard at exact specified dimensions
         const { backgroundColor, backgroundImage } = artboardBackground(artboard);
-        const imageDataUrl = await toPng(artboardElement, {
+        const imageDataUrl = await captureArtboardImage(artboardElement, {
+          format: image.format,
+          quality: image.quality,
+          backgroundColor,
+          backgroundImage,
           width: artboard.size.width,
           height: artboard.size.height,
-          backgroundColor,
-          pixelRatio: 1, // Set to 1 to avoid doubling resolution
-          cacheBust: true, // Prevent caching issues
-          // Editor chrome (selection outlines, resize handles, upload buttons)
-          // must never be baked into the exported image
-          filter: (node) => {
-            const el = node as HTMLElement;
-            return !(el?.hasAttribute?.('data-export-exclude') || el?.hasAttribute?.('data-interaction-handle'));
-          },
-          style: {
-            width: `${artboard.size.width}px`,
-            height: `${artboard.size.height}px`,
-            backgroundImage,
-          }
         });
-        
+
         // Restore original styling after export
         artboardElement.style.transform = originalTransform;
         artboardElement.style.width = originalWidth;
@@ -1364,7 +1452,7 @@ export function OpenScreenshotGeneratorLayout() {
           ? DEVICE_FORMAT_PRESETS.find((p) => p.id === artboardFormat)?.label
           : undefined;
         const deviceSuffix = deviceLabel ? `_${deviceLabel.replace(/\s+/g, '_')}` : '';
-        const filename = `${orderPrefix}_${artboard.name.replace(/\s+/g, '_')}${deviceSuffix}.png`;
+        const filename = `${orderPrefix}_${artboard.name.replace(/\s+/g, '_')}${deviceSuffix}${EXPORT_FORMAT_EXTENSION[image.format]}`;
         progress?.report({
           fileIndex: progress.startIndex + index,
           boardName: artboard.name,
@@ -1413,7 +1501,7 @@ export function OpenScreenshotGeneratorLayout() {
   // engine as the Devices menu, rendered, captured, then the original state
   // is restored — plain setArtboards keeps history and the saved project
   // untouched, so this can never corrupt the user's work.
-  const handleConfirmExport = async ({ asIs, generateFormats, currentArtboardOnly }: ExportSelection) => {
+  const handleConfirmExport = async ({ asIs, generateFormats, currentArtboardOnly, format, quality }: ExportSelection) => {
     setIsExportDialogOpen(false);
 
     const original = artboards;
@@ -1462,6 +1550,7 @@ export function OpenScreenshotGeneratorLayout() {
       formats: generateFormats,
       artboardCount: targets.length,
       fileCount: totalFiles,
+      imageFormat: format,
     });
 
     // The progress dialog is on screen for exactly as long as pngProgress is
@@ -1490,7 +1579,7 @@ export function OpenScreenshotGeneratorLayout() {
       window.dispatchEvent(new CustomEvent('artboard:export', { detail: { phase: 'begin' } }));
       await new Promise((resolve) => setTimeout(resolve, 100));
       try {
-        return await captureArtboards(list, exportDir, order, { report, formatLabel, startIndex });
+        return await captureArtboards(list, exportDir, order, { report, formatLabel, startIndex }, { format, quality });
       } finally {
         window.dispatchEvent(new CustomEvent('artboard:export', { detail: { phase: 'end' } }));
       }
@@ -3640,7 +3729,14 @@ const generateRandomProjectName = (): string => {
               onExportVideo={handleExportVideo}
               onCancelVideoExport={handleCancelVideoExport}
               onExportStills={(currentArtboardOnly) =>
-                handleConfirmExport({ asIs: true, generateFormats: [], currentArtboardOnly })
+                handleConfirmExport({
+                  asIs: true,
+                  generateFormats: [],
+                  currentArtboardOnly,
+                  // Stills from the video dialog stay PNG, their original format.
+                  format: 'png',
+                  quality: 0.92,
+                })
               }
               videoProgress={videoProgress}
               isVideoExporting={isVideoExporting}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -76,12 +76,14 @@ export function trackExportPng(params: {
   formats?: string[];
   artboardCount: number;
   fileCount: number;
+  imageFormat?: 'png' | 'jpeg' | 'webp';
 }): void {
   track('export_png', {
     mode: params.mode,
     formats: params.formats?.join(',') || 'none',
     artboard_count: params.artboardCount,
     file_count: params.fileCount,
+    image_format: params.imageFormat ?? 'png',
   });
 }
 

--- a/src/services/fontService.ts
+++ b/src/services/fontService.ts
@@ -64,12 +64,34 @@ export function createGoogleFontsUrl(fonts: GoogleFont[] = GOOGLE_FONTS): string
   return `https://fonts.googleapis.com/css2?${families.map(f => `family=${f}`).join('&')}&display=swap`;
 }
 
-// Function to preload Google fonts
+// Function to preload Google fonts. html-to-image walks sheet.cssRules of
+// every document stylesheet on each export, and a cross-origin <link> to
+// fonts.googleapis.com throws a SecurityError it can only console.error (once
+// per export, per sheet). To keep the CSS readable we fetch the css2 text and
+// inject it as an inline same-origin <style>. The <link> stays as a fallback
+// for when the fetch fails (offline).
 export function preloadGoogleFonts(fonts: GoogleFont[] = GOOGLE_FONTS): void {
-  const link = document.createElement('link');
-  link.rel = 'stylesheet';
-  link.href = createGoogleFontsUrl(fonts);
-  document.head.appendChild(link);
+  const href = createGoogleFontsUrl(fonts);
+
+  fetch(href)
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error(`Google Fonts request failed with status ${response.status}`);
+      }
+      return response.text();
+    })
+    .then((css) => {
+      const style = document.createElement('style');
+      style.setAttribute('data-google-fonts', '');
+      style.textContent = css;
+      document.head.appendChild(style);
+    })
+    .catch(() => {
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = href;
+      document.head.appendChild(link);
+    });
 }
 
 // Get font options for select components


### PR DESCRIPTION
## What
Extends the export dialog (including your new single-artboard scope and progress flow) with image format choices and more robust font embedding:

1. **Format selector: PNG (default) / JPEG / WebP** in the export dialog, plus a quality slider (0.5–1, default 0.92) shown only for JPEG/WebP.
2. **Format-aware capture**: JPEG via `toJpeg` (alpha flattened onto the artboard background color); WebP via PNG capture → hidden canvas pre-filled with the background color → `canvas.toBlob('image/webp')`. Correct extensions (`.jpg`). Works for both the all-artboards and `currentArtboardOnly` paths and feeds the existing progress events. Video (AppPreview) and MCP stills stay PNG-only.
3. **Font-embedding hardening**: `preloadGoogleFonts` now fetches the Google Fonts css2 text and injects it as a same-origin inline `<style data-google-fonts>` instead of a cross-origin `<link>` — html-to-image's font walker reads `sheet.cssRules` on every export and logs 2 SecurityErrors per export on the cross-origin sheet. Each artboard capture is also wrapped in try/catch with a single `skipFonts: true` retry (warning toast if used), styles restored in `finally`.

## Why
Export previously produced PNG only; JPEG/WebP are the formats most store workflows actually accept, and the font errors were noise in every export.

## Verification
- `npm run typecheck`: only the pre-existing baseline (promo/* remotion + fontLanguageMatcher)
- `npm run build`: passes
- Headless Chromium: 97/97 checks across 6 export runs (all artboards + single artboard × PNG/JPEG/WebP): correct extensions/MIME, 1290×2796 decode, non-blank pixels, JPEG/WebP opaque, quality slider only on JPEG/WebP, progress dialog works, **0 console errors** (vs 2+ per export on main). Retry wiring fault-injected 7/7.