### PR TITLE
Uploads library, OS file drops on canvas, and bulk-drop template proposal (closes #5, #3)

### DIFF
--- a/src/components/open-screenshot-generator/Artboard.tsx
+++ b/src/components/open-screenshot-generator/Artboard.tsx
@@ -12,6 +12,7 @@ import { VideoDeviceElement } from './elements/VideoDeviceElement';
 import { GestureElement } from './elements/GestureElement';
 import type { ArtboardState as ArtboardType, ArtboardElement, Point, ElementType, ShapeType, DeviceType, DeviceFrameElementProps, ImageElementProps, ShapeElementProps, TextElementProps, VideoElementProps, VideoDeviceElementProps, GestureElementProps, GestureType } from '@/types/artboard';
 import { useToast } from '@/hooks/use-toast';
+import { readScreenshotFile, type UploadedScreenshot } from '@/lib/ai/imageUtils';
 import { artboardBackground } from '@/lib/artboardBackground';
 import { cn } from '@/lib/utils';
 import { ArtboardToolbar } from './ArtboardToolbar'; // Import the new toolbar
@@ -46,6 +47,26 @@ interface ArtboardProps {
 export interface ArtboardRef {
   addElement: (type: ElementType, subType?: ShapeType | DeviceType, dropPosition?: Point, styleProps?: Record<string, any>) => string | undefined;
   deleteElementByIdG: (elementId: string) => void;
+  // OS file drop routed from the canvas (a drop on empty canvas chrome has no
+  // element target, so every file becomes an image element). Single commit.
+  addDroppedImageFiles: (files: File[], clientPoint: Point) => void;
+}
+
+// Horizontal/vertical step between images dropped together (artboard px).
+const DROP_CASCADE_OFFSET = 48;
+
+/** Fill a device frame's screenshot, keeping the author's screenshotRect crop. */
+function withDroppedScreenshot(
+  element: DeviceFrameElementProps,
+  shot: UploadedScreenshot
+): DeviceFrameElementProps {
+  return {
+    ...element,
+    screenshotSrc: shot.dataUrl,
+    naturalScreenshotWidth: shot.width,
+    naturalScreenshotHeight: shot.height,
+    screenshotObjectFit: element.screenshotObjectFit ?? 'cover',
+  };
 }
 
 export const Artboard = forwardRef<ArtboardRef, ArtboardProps>(({ 
@@ -136,7 +157,102 @@ export const Artboard = forwardRef<ArtboardRef, ArtboardProps>(({
     setBackgroundStyle(artboardBackground(artboard));
   }, [artboard.elements, artboard.backgroundType, artboard.backgroundColor, artboard.backgroundGradient]);
 
+  // OS image files dropped on this artboard. The first file fills the device
+  // frame under the cursor when there is one (keeping its screenshotRect
+  // crop); every other file becomes an image element at the drop point, in
+  // natural size, cascaded and clamped into the artboard. All of it commits in
+  // ONE onUpdateArtboardElements call, so a multi-file drop is one history
+  // entry.
+  const handleImageFilesDrop = async (files: File[], clientPoint: Point, targetElementId: string | null) => {
+    if (files.length === 0) return;
+    const artboardRect = artboardDivRef.current?.getBoundingClientRect();
+    if (!artboardRect) return;
+    // Same client -> artboard coordinate conversion as addElement.
+    const renderedScale = artboardRect.width > 0
+      ? artboardRect.width / artboard.size.width
+      : displayScaleFactor;
+    const dropX = (clientPoint.x - artboardRect.left) / renderedScale;
+    const dropY = (clientPoint.y - artboardRect.top) / renderedScale;
+
+    const target = targetElementId ? elements.find((el) => el.id === targetElementId) : undefined;
+    const deviceTarget = target && target.type === 'device' ? target : null;
+
+    let shots: UploadedScreenshot[];
+    try {
+      shots = await Promise.all(files.map(readScreenshotFile));
+    } catch {
+      toast({
+        title: 'Could not read those images',
+        description: 'Use PNG, JPEG, WebP, GIF or SVG files.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    const baseElements = deviceTarget
+      ? elements.map((el) =>
+          el.id === deviceTarget.id && el.type === 'device'
+            ? withDroppedScreenshot(el, shots[0])
+            : el
+        )
+      : elements;
+
+    const imageShots = deviceTarget ? shots.slice(1) : shots;
+    const newImages: ImageElementProps[] = imageShots.map((shot, index) => {
+      const width = shot.width || 400;
+      const height = shot.height || 300;
+      return {
+        id: `el_${Date.now()}_${Math.random().toString(36).substr(2, 5)}_${index}`,
+        type: 'image',
+        name: shot.fileName,
+        imageSrc: shot.dataUrl,
+        imageAlt: shot.fileName,
+        objectFit: 'contain',
+        opacity: 1,
+        borderRadius: 0,
+        skewX: 0,
+        skewY: 0,
+        perspectiveX: 0,
+        perspectiveY: 0,
+        matrix3d: '',
+        rotation: 0,
+        scale: 1,
+        size: { width, height },
+        position: {
+          x: Math.max(0, Math.min(dropX - width / 2 + index * DROP_CASCADE_OFFSET, artboard.size.width - width)),
+          y: Math.max(0, Math.min(dropY - height / 2 + index * DROP_CASCADE_OFFSET, artboard.size.height - height)),
+        },
+      };
+    });
+
+    const nextElements = [...baseElements, ...newImages];
+    setElements(nextElements);
+    onUpdateArtboardElements(nextElements);
+
+    const selectId = deviceTarget ? deviceTarget.id : newImages[0]?.id;
+    if (selectId) setSelectedElementId(selectId);
+    if (deviceTarget && newImages.length > 0) {
+      toast({
+        title: 'Images Added',
+        description: `Filled "${deviceTarget.name || 'Device'}" and added ${newImages.length} more image${newImages.length === 1 ? '' : 's'}.`,
+      });
+    } else if (deviceTarget) {
+      toast({
+        title: 'Screenshot Placed',
+        description: `Filled "${deviceTarget.name || 'Device'}" with your screenshot.`,
+      });
+    } else {
+      toast({
+        title: 'Images Added',
+        description: `${newImages.length} image${newImages.length === 1 ? '' : 's'} added to "${artboard.name}".`,
+      });
+    }
+  };
+
   useImperativeHandle(ref, () => ({
+    addDroppedImageFiles: (files: File[], clientPoint: Point) => {
+      void handleImageFilesDrop(files, clientPoint, null);
+    },
     addElement: (type: ElementType, subType?: ShapeType | DeviceType, dropPosition?: Point, styleProps?: Record<string, any>) => {
       const artboardRect = artboardDivRef.current?.getBoundingClientRect();
       let newElementX = artboard.size.width / 2 - 50; 
@@ -561,6 +677,22 @@ export const Artboard = forwardRef<ArtboardRef, ArtboardProps>(({
           onDrop={(e) => {
             e.preventDefault();
             e.stopPropagation();
+            // OS file drop: image files land as image elements (or fill the
+            // device frame under the cursor). Palette drags carry no files,
+            // so they fall through to the custom MIME path below.
+            const imageFiles = Array.from(e.dataTransfer.files).filter((file) => file.type.startsWith('image/'));
+            if (imageFiles.length > 0) {
+              const targetId = (e.target as HTMLElement).closest('[data-element-id]')?.getAttribute('data-element-id') ?? null;
+              void handleImageFilesDrop(imageFiles, { x: e.clientX, y: e.clientY }, targetId);
+              return;
+            }
+            if (e.dataTransfer.files.length > 0) {
+              toast({
+                title: 'Unsupported file',
+                description: 'Drop image files (PNG, JPEG, WebP, GIF or SVG). Recordings are added to video elements.',
+              });
+              return;
+            }
             const type = e.dataTransfer.getData('application/artboard-element-type') as ElementType;
             const subType = e.dataTransfer.getData('application/artboard-element-subtype') as ShapeType | DeviceType | undefined;
             const rawStyleProps = e.dataTransfer.getData('application/artboard-element-styleprops');

--- a/src/components/open-screenshot-generator/Artboard.tsx
+++ b/src/components/open-screenshot-generator/Artboard.tsx
@@ -25,8 +25,13 @@ interface ArtboardProps {
   onUpdateArtboardDetails: (updatedDetails: Partial<ArtboardType>) => void;
   onSelectArtboard: () => void;
   globalZoom: number;
-  selectedElementId: string | null;
-  setSelectedElementId: (id: string | null) => void;
+  // Ids of the selected elements (empty when nothing is selected). Selection
+  // is scoped to this artboard by the parent, which passes [] for inactive
+  // artboards.
+  selectedElementIds: string[];
+  // Plain selection passes the id alone (or null to clear); { additive: true }
+  // toggles the id in/out of the current selection (Shift/Ctrl/Cmd click).
+  setSelectedElementId: (id: string | null, modifiers?: { additive?: boolean }) => void;
   // Props for the ArtboardToolbar
   onAddNewArtboard: () => void;
   onDuplicateArtboard: (artboardId: string) => void;
@@ -50,7 +55,7 @@ export const Artboard = forwardRef<ArtboardRef, ArtboardProps>(({
   onUpdateArtboardDetails,
   onSelectArtboard, 
   globalZoom,
-  selectedElementId,
+  selectedElementIds,
   setSelectedElementId,
   onAddNewArtboard,
   onDuplicateArtboard,
@@ -138,9 +143,14 @@ export const Artboard = forwardRef<ArtboardRef, ArtboardProps>(({
       let newElementY = artboard.size.height / 2 - 25;
       
       if (dropPosition && artboardRect) {
-        // Adjust drop position to account for scaling
-        newElementX = (dropPosition.x - artboardRect.left) / displayScaleFactor - 50;
-        newElementY = (dropPosition.y - artboardRect.top) / displayScaleFactor - 25;
+        // Adjust drop position for every ancestor zoom via the rendered size
+        // (display scale * canvas zoom), so the element lands under the cursor
+        // at any zoom level.
+        const renderedScale = artboardRect.width > 0
+          ? artboardRect.width / artboard.size.width
+          : displayScaleFactor;
+        newElementX = (dropPosition.x - artboardRect.left) / renderedScale - 50;
+        newElementY = (dropPosition.y - artboardRect.top) / renderedScale - 25;
       }
       
       newElementX = Math.max(0, Math.min(newElementX, artboard.size.width - 100));
@@ -373,7 +383,8 @@ export const Artboard = forwardRef<ArtboardRef, ArtboardProps>(({
         const newElements = elements.filter(el => el.id !== elementId);
         setElements(newElements);
         onUpdateArtboardElements(newElements);
-        setSelectedElementId(null);
+        // No selection cleanup here: handleArtboardsUpdate prunes ids that no
+        // longer exist from the parent's selection state.
         console.log(`Element deleted: ${elementId}`);
         return true;
       }
@@ -401,14 +412,75 @@ export const Artboard = forwardRef<ArtboardRef, ArtboardProps>(({
     const newElements = elements.filter(el => el.id !== elementId);
     setElements(newElements);
     onUpdateArtboardElements(newElements);
-    if (selectedElementId === elementId) {
-      setSelectedElementId(null);
-    }
+    // Selection cleanup happens centrally in handleArtboardsUpdate.
   };
 
-  const handleSelectElement = (elementId: string, e: React.MouseEvent) => {
-    e.stopPropagation(); 
-    setSelectedElementId(elementId);
+  // Mirror of the selection prop that stays synchronous across mousedown ->
+  // drag-start, before the parent's state update has re-rendered us. The
+  // group-drag hooks read this so a Shift+click-then-drag in one gesture
+  // still engages the multi-drag.
+  const selectionIdsRef = useRef<string[]>(selectedElementIds);
+  useEffect(() => {
+    selectionIdsRef.current = selectedElementIds;
+  }, [selectedElementIds]);
+
+  // Snapshot taken when a group drag starts; the dragged element's
+  // DraggableElement reports deltas and every selected element is translated
+  // locally (no parent update) until mouseup commits once.
+  const multiDragRef = useRef<{
+    startElements: ArtboardElement[];
+    selectedIds: string[];
+    lastDelta: Point;
+  } | null>(null);
+
+  const handleSelectElement = (elementId: string, modifiers?: { additive?: boolean }) => {
+    const current = selectionIdsRef.current;
+    const next = modifiers?.additive
+      ? (current.includes(elementId) ? current.filter((id) => id !== elementId) : [...current, elementId])
+      : [elementId];
+    selectionIdsRef.current = next;
+    setSelectedElementId(elementId, modifiers);
+  };
+
+  const handleGroupDragStart = (elementId: string): boolean => {
+    const ids = selectionIdsRef.current;
+    if (ids.length <= 1 || !ids.includes(elementId)) return false;
+    multiDragRef.current = {
+      startElements: elements,
+      selectedIds: [...ids],
+      lastDelta: { x: 0, y: 0 },
+    };
+    return true;
+  };
+
+  const translateMultiDrag = (drag: NonNullable<typeof multiDragRef.current>): ArtboardElement[] => {
+    const ids = new Set(drag.selectedIds);
+    return drag.startElements.map((el) =>
+      ids.has(el.id)
+        ? ({ ...el, position: { x: el.position.x + drag.lastDelta.x, y: el.position.y + drag.lastDelta.y } } as ArtboardElement)
+        : el
+    );
+  };
+
+  const handleGroupDragMove = (dx: number, dy: number) => {
+    const drag = multiDragRef.current;
+    if (!drag) return;
+    drag.lastDelta = { x: dx, y: dy };
+    // Transient local update only: the parent (and history) see one commit on
+    // mouseup, not one per mousemove per element.
+    setElements(translateMultiDrag(drag));
+  };
+
+  const handleGroupDragEnd = (dx: number, dy: number) => {
+    const drag = multiDragRef.current;
+    if (!drag) return;
+    multiDragRef.current = null;
+    drag.lastDelta = { x: dx, y: dy };
+    const finalElements = translateMultiDrag(drag);
+    setElements(finalElements);
+    if (dx !== 0 || dy !== 0) {
+      onUpdateArtboardElements(finalElements);
+    }
   };
 
   const handleArtboardClick = (e: React.MouseEvent<HTMLDivElement>) => {
@@ -512,18 +584,22 @@ export const Artboard = forwardRef<ArtboardRef, ArtboardProps>(({
             <DraggableElement
               key={element.id}
               element={element}
-              isSelected={selectedElementId === element.id}
+              isSelected={selectedElementIds.includes(element.id)}
               onSelect={handleSelectElement}
               onUpdateElement={handleUpdateElement}
               onDeleteElement={handleDeleteElement}
               artboardZoom={artboard.zoom}
+              canvasZoom={globalZoom}
+              onGroupDragStart={handleGroupDragStart}
+              onGroupDragMove={handleGroupDragMove}
+              onGroupDragEnd={handleGroupDragEnd}
               boundary={{width: artboard.size.width, height: artboard.size.height}}
             >
               {element.type === 'text' && (
                 <TextElement 
                   element={element} 
                   onUpdate={(updates) => partialUpdateElement(element.id, updates)} 
-                  isSelected={selectedElementId === element.id}
+                  isSelected={selectedElementIds.includes(element.id)}
                   artboardZoom={artboard.zoom * element.scale}
                 />
               )}
@@ -531,7 +607,7 @@ export const Artboard = forwardRef<ArtboardRef, ArtboardProps>(({
                 <ImageElement 
                   element={element as ImageElementProps} 
                   onUpdate={(updates) => partialUpdateElement(element.id, updates)} 
-                  isSelected={selectedElementId === element.id}
+                  isSelected={selectedElementIds.includes(element.id)}
                 />
               )}
               {element.type === 'shape' && <ShapeElement element={element} />}
@@ -539,27 +615,27 @@ export const Artboard = forwardRef<ArtboardRef, ArtboardProps>(({
                 <DeviceFrameElement
                   element={element}
                   onUpdate={(updates) => partialUpdateElement(element.id, updates)}
-                  isSelected={selectedElementId === element.id}
+                  isSelected={selectedElementIds.includes(element.id)}
                 />
               )}
               {element.type === 'video' && (
                 <VideoElement
                   element={element as VideoElementProps}
                   onUpdate={(updates) => partialUpdateElement(element.id, updates)}
-                  isSelected={selectedElementId === element.id}
+                  isSelected={selectedElementIds.includes(element.id)}
                 />
               )}
               {element.type === 'video-device' && (
                 <VideoDeviceElement
                   element={element as VideoDeviceElementProps}
                   onUpdate={(updates) => partialUpdateElement(element.id, updates)}
-                  isSelected={selectedElementId === element.id}
+                  isSelected={selectedElementIds.includes(element.id)}
                 />
               )}
               {element.type === 'gesture' && (
                 <GestureElement
                   element={element as GestureElementProps}
-                  isSelected={selectedElementId === element.id}
+                  isSelected={selectedElementIds.includes(element.id)}
                 />
               )}
             </DraggableElement>

--- a/src/components/open-screenshot-generator/CanvasArea.tsx
+++ b/src/components/open-screenshot-generator/CanvasArea.tsx
@@ -1,12 +1,13 @@
 "use client";
 import type React from 'react';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useLayoutEffect, useRef } from 'react';
 import { Artboard } from './Artboard';
 import type { ArtboardState, Point, ElementType, ShapeType, DeviceType, ArtboardElement } from '@/types/artboard';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useToast } from '@/hooks/use-toast';
 import { DeleteArtboardDialog } from './DeleteArtboardDialog'; // Import the new dialog component
+import { elementBounds } from '@/lib/elementAlignment';
 
 interface CanvasAreaProps {
   artboards: ArtboardState[];
@@ -14,9 +15,13 @@ interface CanvasAreaProps {
   onAddElementToArtboard: (artboardId: string, type: ElementType, subType?: ShapeType | DeviceType, dropPosition?: Point, styleProps?: Record<string, any>) => void;
   activeArtboardId: string | null;
   setActiveArtboardId: (id: string | null) => void;
-  selectedElementIdOnActiveArtboard: string | null;
-  setSelectedElementIdOnActiveArtboard: (elementId: string | null) => void;
+  selectedElementIdsOnActiveArtboard: string[];
+  setSelectedElementIdOnActiveArtboard: (elementId: string | null, modifiers?: { additive?: boolean }) => void;
+  // Bulk replace, used by the marquee (rubber-band) selection.
+  setSelectedElementIdsOnActiveArtboard: (elementIds: string[]) => void;
   canvasZoom: number;
+  // Wheel-zoom updates flow back to the parent so the zoom pill stays in sync.
+  onCanvasZoomChange: (zoom: number) => void;
   artboardRefs: React.MutableRefObject<Record<string, any>>;
   onAddNewArtboardFromToolbar: (currentArtboardId: string) => void;
   onDuplicateArtboardFromToolbar: (artboardId: string) => void;
@@ -37,9 +42,11 @@ export function CanvasArea({
     onAddElementToArtboard,
     activeArtboardId,
     setActiveArtboardId,
-    selectedElementIdOnActiveArtboard,
+    selectedElementIdsOnActiveArtboard,
     setSelectedElementIdOnActiveArtboard,
+    setSelectedElementIdsOnActiveArtboard,
     canvasZoom,
+    onCanvasZoomChange,
     artboardRefs,
     onAddNewArtboardFromToolbar,
     onDuplicateArtboardFromToolbar,
@@ -57,6 +64,7 @@ export function CanvasArea({
   const artboards = externalArtboards;
   const scrollViewportRef = useRef<HTMLDivElement>(null);
   const contentAreaRef = useRef<HTMLDivElement>(null);
+  const contentInnerRef = useRef<HTMLDivElement>(null);
   const { toast } = useToast();
 
   // State for artboard deletion confirmation
@@ -65,6 +73,70 @@ export function CanvasArea({
 
   const [isPanning, setIsPanning] = useState(false);
   const panStartCoords = useRef<{ x: number, y: number, scrollLeft: number, scrollTop: number } | null>(null);
+
+  // Marquee (rubber-band) selection. The rectangle is painted by mutating the
+  // overlay div's style directly during mousemove, so a drag does not
+  // re-render the artboard subtree sixty times a second.
+  const [marqueeActive, setMarqueeActive] = useState(false);
+  const marqueeDivRef = useRef<HTMLDivElement>(null);
+  const marqueeStartRef = useRef<{
+    startX: number;
+    startY: number;
+    scopeArtboardId: string | null;
+    clickedArtboardId: string | null;
+    additive: boolean;
+  } | null>(null);
+
+  // Latest-values mirror for the marquee/wheel handlers, which register
+  // document listeners that must not capture stale state.
+  const latestRef = useRef({ artboards, activeArtboardId, selectedElementIdsOnActiveArtboard });
+  latestRef.current = { artboards, activeArtboardId, selectedElementIdsOnActiveArtboard };
+
+  // Mouse-wheel zoom, anchored at the cursor. Non-passive so preventDefault
+  // can stop the page scroll while zooming. Pans (Shift/Alt, horizontal
+  // trackpad deltas) keep the native scroll behavior; only zoom gestures are
+  // intercepted. Pinch-to-zoom arrives as ctrlKey+wheel and zooms too.
+  const canvasZoomRef = useRef(canvasZoom);
+  canvasZoomRef.current = canvasZoom;
+  const zoomAnchorRef = useRef<{ contentX: number; contentY: number; relX: number; relY: number } | null>(null);
+
+  useEffect(() => {
+    const viewport = scrollViewportRef.current;
+    if (!viewport) return;
+    const handleWheel = (e: WheelEvent) => {
+      const isPan = e.shiftKey || e.altKey || (!e.ctrlKey && Math.abs(e.deltaX) > Math.abs(e.deltaY));
+      if (isPan) return;
+      e.preventDefault();
+      const oldZoom = canvasZoomRef.current;
+      const nextZoom = Math.min(4, Math.max(0.1, oldZoom * Math.exp(-e.deltaY * 0.002)));
+      if (nextZoom === oldZoom) return;
+      const rect = viewport.getBoundingClientRect();
+      const relX = e.clientX - rect.left;
+      const relY = e.clientY - rect.top;
+      // Content point under the cursor, in unscaled content coordinates. The
+      // layout effect below re-anchors it after the zoom render lands.
+      zoomAnchorRef.current = {
+        contentX: (relX + viewport.scrollLeft) / oldZoom,
+        contentY: (relY + viewport.scrollTop) / oldZoom,
+        relX,
+        relY,
+      };
+      onCanvasZoomChange(nextZoom);
+    };
+    viewport.addEventListener('wheel', handleWheel, { passive: false });
+    return () => viewport.removeEventListener('wheel', handleWheel);
+  }, [onCanvasZoomChange]);
+
+  // Keep the cursor-anchored content point fixed across a wheel zoom by
+  // adjusting the scroll offsets once the new transform is committed.
+  useLayoutEffect(() => {
+    const anchor = zoomAnchorRef.current;
+    const viewport = scrollViewportRef.current;
+    if (!anchor || !viewport) return;
+    zoomAnchorRef.current = null;
+    viewport.scrollLeft = anchor.contentX * canvasZoom - anchor.relX;
+    viewport.scrollTop = anchor.contentY * canvasZoom - anchor.relY;
+  }, [canvasZoom]);
 
 
   // Safety net: if real artboards exist but none is selected (e.g. after a
@@ -111,13 +183,160 @@ export function CanvasArea({
         if (contentAreaRef.current) contentAreaRef.current.style.cursor = 'grabbing';
       }
     } else if (activeTool === 'select') {
-      // Only deselect if the click is on the direct background of the content area
-      if (e.target === contentAreaRef.current) { 
-        setActiveArtboardId(null);
-        setSelectedElementIdOnActiveArtboard(null);
+      if (e.button !== 0) return;
+      const target = e.target as HTMLElement;
+      // Element mousedowns never reach here (DraggableElement stops
+      // propagation); handles and the artboard toolbar are not marquee ground.
+      if (target.closest('[data-interaction-handle]') || target.closest('[data-element-id]')) return;
+      const artboardNode = target.closest('[data-artboard-dom-id]') as HTMLElement | null;
+      const isEmptyCanvas = target === contentAreaRef.current || target === contentInnerRef.current;
+      // Clicks on artboard chrome (name label, toolbar) neither deselect nor marquee.
+      if (!artboardNode && !isEmptyCanvas) return;
+
+      // preventDefault blocks the native focus transfer, so blur (and commit)
+      // any pending panel/canvas text edit explicitly before starting.
+      const active = document.activeElement as HTMLElement | null;
+      if (active && (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA' || active.isContentEditable)) {
+        active.blur();
       }
+      e.preventDefault();
+
+      const clickedArtboardId = artboardNode?.getAttribute('data-artboard-dom-id') ?? null;
+      if (clickedArtboardId && clickedArtboardId !== latestRef.current.activeArtboardId) {
+        setActiveArtboardId(clickedArtboardId);
+      }
+      marqueeStartRef.current = {
+        startX: e.clientX,
+        startY: e.clientY,
+        // A drag that began on an artboard tests only that artboard; one that
+        // began on empty canvas falls back to the active artboard.
+        scopeArtboardId: clickedArtboardId ?? latestRef.current.activeArtboardId,
+        clickedArtboardId,
+        additive: e.shiftKey || e.ctrlKey || e.metaKey,
+      };
+      setMarqueeActive(true);
     }
   };
+
+  // Marquee drag tracking + finalization. Registered once per drag; the
+  // overlay div is positioned by direct style mutation.
+  useEffect(() => {
+    if (!marqueeActive) return;
+    const start = marqueeStartRef.current;
+    const overlay = marqueeDivRef.current;
+    if (!start || !overlay) return;
+
+    let currentX = start.startX;
+    let currentY = start.startY;
+    let dragged = false;
+
+    const paintOverlay = () => {
+      overlay.style.left = `${Math.min(start.startX, currentX)}px`;
+      overlay.style.top = `${Math.min(start.startY, currentY)}px`;
+      overlay.style.width = `${Math.abs(currentX - start.startX)}px`;
+      overlay.style.height = `${Math.abs(currentY - start.startY)}px`;
+    };
+    paintOverlay();
+
+    const handleMouseMove = (e: MouseEvent) => {
+      e.preventDefault();
+      currentX = e.clientX;
+      currentY = e.clientY;
+      if (Math.abs(currentX - start.startX) > 3 || Math.abs(currentY - start.startY) > 3) {
+        dragged = true;
+      }
+      paintOverlay();
+    };
+
+    const handleMouseUp = () => {
+      setMarqueeActive(false);
+      const { artboards: currentArtboards, activeArtboardId: currentActiveId, selectedElementIdsOnActiveArtboard: currentSelection } = latestRef.current;
+
+      if (!dragged) {
+        // Plain click on background: clear the element selection, and on
+        // empty canvas also drop the active artboard (previous behavior).
+        if (!start.additive) {
+          setSelectedElementIdsOnActiveArtboard([]);
+          if (!start.clickedArtboardId) setActiveArtboardId(null);
+        }
+        return;
+      }
+
+      // The mouseup is followed by a click event on the same background;
+      // swallow it once so it cannot clear the selection the marquee just made.
+      const swallowClick = (ev: MouseEvent) => {
+        ev.stopPropagation();
+        ev.preventDefault();
+      };
+      document.addEventListener('click', swallowClick, { capture: true, once: true });
+      window.setTimeout(() => document.removeEventListener('click', swallowClick, true), 100);
+
+      const marqueeRect = {
+        left: Math.min(start.startX, currentX),
+        top: Math.min(start.startY, currentY),
+        right: Math.max(start.startX, currentX),
+        bottom: Math.max(start.startY, currentY),
+      };
+
+      const candidates = start.scopeArtboardId && currentArtboards.some((ab) => ab.id === start.scopeArtboardId)
+        ? currentArtboards.filter((ab) => ab.id === start.scopeArtboardId)
+        : currentArtboards;
+
+      // Convert the screen-space rectangle into each artboard's coordinate
+      // space via its rendered size, then keep the intersecting elements.
+      let best: { artboardId: string; ids: string[] } | null = null;
+      for (const ab of candidates) {
+        const node = contentInnerRef.current?.querySelector(`[data-artboard-dom-id="${ab.id}"]`) as HTMLElement | null;
+        if (!node) continue;
+        const rect = node.getBoundingClientRect();
+        const originalWidth = Number(node.getAttribute('data-original-width')) || ab.size.width;
+        const scale = rect.width > 0 && originalWidth > 0 ? rect.width / originalWidth : 1;
+        const area = {
+          left: (marqueeRect.left - rect.left) / scale,
+          top: (marqueeRect.top - rect.top) / scale,
+          right: (marqueeRect.right - rect.left) / scale,
+          bottom: (marqueeRect.bottom - rect.top) / scale,
+        };
+        const ids = ab.elements
+          .filter((el) => {
+            const b = elementBounds(el);
+            return b.left < area.right && b.right > area.left && b.top < area.bottom && b.bottom > area.top;
+          })
+          .map((el) => el.id);
+        if (ids.length === 0) continue;
+        if (start.scopeArtboardId === ab.id) {
+          best = { artboardId: ab.id, ids };
+          break;
+        }
+        if (!best || ids.length > best.ids.length) {
+          best = { artboardId: ab.id, ids };
+        }
+      }
+
+      if (best) {
+        if (best.artboardId !== currentActiveId) {
+          setActiveArtboardId(best.artboardId);
+        }
+        if (start.additive && best.artboardId === currentActiveId) {
+          setSelectedElementIdsOnActiveArtboard([...new Set([...currentSelection, ...best.ids])]);
+        } else {
+          setSelectedElementIdsOnActiveArtboard(best.ids);
+        }
+      } else if (!start.additive) {
+        setSelectedElementIdsOnActiveArtboard([]);
+      }
+    };
+
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+    };
+    // The drag's fixed start data lives in marqueeStartRef; re-running only on
+    // activation keeps the listeners stable for the whole gesture.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [marqueeActive]);
 
   useEffect(() => {
     const scrollViewport = scrollViewportRef.current;
@@ -213,6 +432,7 @@ export function CanvasArea({
   };
   
   return (
+    <>
     <ScrollArea
       className="h-full w-full bg-background flex-grow"
       viewportRef={scrollViewportRef}
@@ -233,10 +453,12 @@ export function CanvasArea({
         onDrop={handleDropOnCanvas}
         onDragOver={handleDragOverCanvas}
       >
+        {/* The canvas zoom lives ONLY on the outer wrapper above. A second
+            scale() here used to compound it into canvasZoom², which is what
+            made element drags outrun the cursor at any zoom but 100%. */}
         <div
+          ref={contentInnerRef}
           style={{
-            transform: `scale(${canvasZoom})`,
-            transformOrigin: 'top left',
             width: "100%",
             height: "100%",
           }}
@@ -279,13 +501,13 @@ export function CanvasArea({
                 onUpdateArtboardDetails={(details) => handleUpdateArtboardDetails(artboard.id, details)}
                 onSelectArtboard={() => handleSelectArtboard(artboard.id)}
                 globalZoom={canvasZoom}
-                selectedElementId={activeArtboardId === artboard.id ? selectedElementIdOnActiveArtboard : null}
-                setSelectedElementId={(elementId) => {
+                selectedElementIds={activeArtboardId === artboard.id ? selectedElementIdsOnActiveArtboard : []}
+                setSelectedElementId={(elementId, modifiers) => {
                   // Always set the active artboard when selecting an element
                   if (elementId && activeArtboardId !== artboard.id) {
                     setActiveArtboardId(artboard.id);
                   }
-                  setSelectedElementIdOnActiveArtboard(elementId);
+                  setSelectedElementIdOnActiveArtboard(elementId, modifiers);
                 }}
                 onAddNewArtboard={() => onAddNewArtboardFromToolbar(artboard.id)}
                 onDuplicateArtboard={onDuplicateArtboardFromToolbar}
@@ -312,6 +534,17 @@ export function CanvasArea({
         </div>
       </div>
     </ScrollArea>
+
+    {/* Marquee selection rectangle. position:fixed in client coordinates, so
+        it must live outside the zoomed (transformed) content tree. */}
+    {marqueeActive && (
+      <div
+        ref={marqueeDivRef}
+        data-export-exclude
+        className="pointer-events-none fixed z-50 border border-primary bg-primary/10"
+      />
+    )}
+    </>
   );
 }
 

--- a/src/components/open-screenshot-generator/CanvasArea.tsx
+++ b/src/components/open-screenshot-generator/CanvasArea.tsx
@@ -34,6 +34,9 @@ interface CanvasAreaProps {
   // fake placeholder artboard. Artboard positioning is owned by the parent
   // (calculateArtboardPositions in OpenScreenshotGeneratorLayout), not here.
   isLoading?: boolean;
+  // OS image files dropped on a canvas with no artboards yet: the parent
+  // offers to auto-build a project from them (template proposal flow).
+  onImagesDroppedOnEmptyCanvas?: (files: File[]) => void;
 }
 
 export function CanvasArea({
@@ -55,6 +58,7 @@ export function CanvasArea({
     onTranslateArtboard,
     activeTool,
     isLoading = false,
+    onImagesDroppedOnEmptyCanvas,
 }: CanvasAreaProps) {
   // The parent is the single source of truth for artboards. We render the prop
   // directly (no private mirror copy) so a newly loaded template paints on the
@@ -373,6 +377,36 @@ export function CanvasArea({
 
   const handleDropOnCanvas = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
+    // OS file drop (no custom palette MIME). A drop straight onto an artboard
+    // is handled by Artboard's own onDrop and never reaches here; this path
+    // covers empty canvas chrome: route to the active artboard, or offer the
+    // bulk template proposal when there is nothing to drop onto yet.
+    const imageFiles = Array.from(e.dataTransfer.files).filter((file) => file.type.startsWith('image/'));
+    if (imageFiles.length > 0) {
+      if (artboards.length === 0) {
+        if (imageFiles.length >= 2 && onImagesDroppedOnEmptyCanvas) {
+          onImagesDroppedOnEmptyCanvas(imageFiles);
+        } else {
+          toast({ title: "No Artboard Yet", description: "Start a project first, then drop your image onto an artboard." });
+        }
+        return;
+      }
+      if (activeArtboardId) {
+        const artboardComponent = artboardRefs.current[activeArtboardId];
+        if (artboardComponent && (artboardComponent as any).addDroppedImageFiles) {
+          (artboardComponent as any).addDroppedImageFiles(imageFiles, { x: e.clientX, y: e.clientY });
+        } else {
+          toast({ title: "Error", description: "Could not add images. Artboard not found or ready.", variant: "destructive"});
+        }
+      } else {
+        toast({ title: "No Artboard Selected", description: "Select an artboard, then drop your images on it.", variant: "destructive"});
+      }
+      return;
+    }
+    if (e.dataTransfer.files.length > 0) {
+      toast({ title: "Unsupported file", description: "Drop image files (PNG, JPEG, WebP, GIF or SVG). Recordings are added to video elements." });
+      return;
+    }
     const type = e.dataTransfer.getData('application/artboard-element-type') as ElementType;
     const subType = e.dataTransfer.getData('application/artboard-element-subtype') as ShapeType | DeviceType | undefined;
     const rawStyleProps = e.dataTransfer.getData('application/artboard-element-styleprops');

--- a/src/components/open-screenshot-generator/ElementPalette.tsx
+++ b/src/components/open-screenshot-generator/ElementPalette.tsx
@@ -1,6 +1,6 @@
 "use client";
 import type React from 'react';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -26,10 +26,13 @@ import {
   MoveHorizontalIcon,
   MoveVerticalIcon,
   LaptopIcon,
+  UploadCloudIcon,
 } from "lucide-react";
 import type { ElementType, ShapeType, DeviceType } from '@/types/artboard';
 import { ELEMENT_CATEGORIES, type ElementCategory, type LibraryElementDef } from '@/lib/elementLibrary';
 import { IMAGE_CATEGORIES, type LibraryImageDef } from '@/lib/imageLibrary';
+import { listUploadedImages, useMediaUrl, type MediaAsset } from '@/lib/mediaStore';
+import { UploadsPanel } from './UploadsPanel';
 // 3D pose tables and colored flat presets live in lib/ so the MCP asset library
 // lists exactly what these tiles drop (see lib/mcp/assetLibrary.ts).
 import {
@@ -194,6 +197,14 @@ const ImageLibraryTile: React.FC<{
   );
 };
 
+/** Mini thumbnail for the "Your uploads" category card, from the shared object-URL cache. */
+const UploadedAssetPreview: React.FC<{ id: string }> = ({ id }) => {
+  const url = useMediaUrl(id);
+  return url ? (
+    <img src={url} alt="" className="max-w-full max-h-full object-contain" draggable={false} />
+  ) : null;
+};
+
 interface ElementPaletteProps {
   onAddElement: (type: ElementType, subType?: ShapeType | DeviceType, styleProps?: Record<string, any>) => void;
 }
@@ -292,6 +303,19 @@ export function ElementPalette({ onAddElement }: ElementPaletteProps) {
   const [openDeviceCategoryId, setOpenDeviceCategoryId] = useState<DeviceCategoryId | null>(null);
   const [openImageCategoryId, setOpenImageCategoryId] = useState<string | null>(null);
   const openImageCategory = IMAGE_CATEGORIES.find(c => c.id === openImageCategoryId) || null;
+
+  // User-uploaded image library (pinned first category in the Images tab).
+  // The palette owns the list so the overview card can preview recent uploads;
+  // the drill-in panel mutates and asks for a re-list via refreshUploads.
+  const [uploadedAssets, setUploadedAssets] = useState<MediaAsset[]>([]);
+  const refreshUploads = useCallback(() => {
+    listUploadedImages()
+      .then(setUploadedAssets)
+      .catch(() => setUploadedAssets([]));
+  }, []);
+  useEffect(() => {
+    refreshUploads();
+  }, [refreshUploads]);
 
   // The layout swaps to the template-selector screen (and back) while a
   // project loads, remounting this palette — keep the chosen tab sticky so it
@@ -804,7 +828,24 @@ export function ElementPalette({ onAddElement }: ElementPaletteProps) {
 
         <TabsContent value="images" className="flex-grow p-3 pt-2 mt-0 min-h-0">
           <ScrollArea className="h-full">
-            {openImageCategory ? (
+            {openImageCategoryId === 'uploads' ? (
+              <div>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="mb-2 h-7 px-1.5 text-xs"
+                  onClick={() => setOpenImageCategoryId(null)}
+                >
+                  <ChevronLeftIcon className="w-4 h-4 mr-0.5" />
+                  Back
+                </Button>
+                <UploadsPanel
+                  assets={uploadedAssets}
+                  onChanged={refreshUploads}
+                  onDragStart={handleDragStart}
+                />
+              </div>
+            ) : openImageCategory ? (
               <div>
                 <Button
                   variant="ghost"
@@ -827,6 +868,17 @@ export function ElementPalette({ onAddElement }: ElementPaletteProps) {
                   <CardTitle className="text-base">Image Library</CardTitle>
                 </CardHeader>
                 <CardContent className="p-2 grid grid-cols-2 gap-x-2 gap-y-3">
+                  <DeviceCategoryCard
+                    label="Your uploads"
+                    onOpen={() => setOpenImageCategoryId('uploads')}
+                    previews={
+                      uploadedAssets.length > 0
+                        ? uploadedAssets.slice(0, 6).map(asset => (
+                            <UploadedAssetPreview key={asset.id} id={asset.id} />
+                          ))
+                        : [<UploadCloudIcon key="empty" className="w-5 h-5 text-primary" />]
+                    }
+                  />
                   {IMAGE_CATEGORIES.map(category => (
                     <DeviceCategoryCard
                       key={category.id}

--- a/src/components/open-screenshot-generator/ExportDialog.tsx
+++ b/src/components/open-screenshot-generator/ExportDialog.tsx
@@ -14,12 +14,17 @@ import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Slider } from "@/components/ui/slider";
 import type { Size } from '@/types/artboard';
 import {
   APP_STORE_FORMAT_IDS,
   DEVICE_FORMAT_PRESETS,
   type DeviceFormat,
 } from '@/lib/deviceRegistry';
+
+// Image encodings the export can produce. JPEG and WebP are lossy and honor
+// `quality`; both flatten transparency onto the artboard background colour.
+export type ExportImageFormat = 'png' | 'jpeg' | 'svg' | 'webp';
 
 export interface ExportSelection {
   // Export the artboards exactly as they are on the canvas.
@@ -30,6 +35,10 @@ export interface ExportSelection {
   generateFormats: DeviceFormat[];
   // Subset of artboard ids to export; omitted means every artboard.
   artboardIds?: string[];
+  // Image encoding for the captures; omitted means PNG.
+  format?: ExportImageFormat;
+  // Lossy quality (0..1) for JPEG and WebP; ignored for PNG and SVG.
+  quality?: number;
 }
 
 // Shared with AppPreviewExportDialog (the video projects' own dialog), which
@@ -72,6 +81,13 @@ const APP_STORE_TIER_NOTES: Partial<Record<DeviceFormat, string>> = {
   'ipad-11': 'Optional — Apple scales your 13-inch shots down if missing',
 };
 
+const IMAGE_FORMAT_OPTIONS: { id: ExportImageFormat; label: string; note: string }[] = [
+  { id: 'png', label: 'PNG', note: 'Lossless, keeps transparency' },
+  { id: 'jpeg', label: 'JPEG', note: 'Smaller files, flattened background' },
+  { id: 'webp', label: 'WebP', note: 'Small files, flattened background' },
+  { id: 'svg', label: 'SVG', note: 'Scalable vector markup' },
+];
+
 export function ExportDialog({
   isOpen,
   onOpenChange,
@@ -84,6 +100,8 @@ export function ExportDialog({
   const [generateFormats, setGenerateFormats] = useState<DeviceFormat[]>([]);
   const [scope, setScope] = useState<'all' | 'pick'>('all');
   const [checkedIds, setCheckedIds] = useState<string[]>([]);
+  const [format, setFormat] = useState<ExportImageFormat>('png');
+  const [quality, setQuality] = useState(0.92);
 
   useEffect(() => {
     // Reset selection whenever the dialog is reopened
@@ -92,6 +110,8 @@ export function ExportDialog({
       setGenerateFormats([]);
       setScope('all');
       setCheckedIds(artboards.map((ab) => ab.id));
+      setFormat('png');
+      setQuality(0.92);
     }
   }, [isOpen, artboards]);
 
@@ -140,7 +160,7 @@ export function ExportDialog({
       scope === 'all'
         ? artboards.map((ab) => ab.id)
         : artboards.filter((ab) => checkedIds.includes(ab.id)).map((ab) => ab.id);
-    onConfirmExport({ asIs, generateFormats, artboardIds });
+    onConfirmExport({ asIs, generateFormats, artboardIds, format, quality });
   };
 
   const asIsDescription = currentPreset
@@ -155,7 +175,7 @@ export function ExportDialog({
         <DialogHeader>
           <DialogTitle>Export Screenshots</DialogTitle>
           <DialogDescription>
-            Download the artboards as PNGs, and optionally generate the App
+            Download the artboards as images, and optionally generate the App
             Store sizes this project is missing. Generated formats convert the
             canvas and mockups on the fly — your project stays untouched.
           </DialogDescription>
@@ -193,6 +213,45 @@ export function ExportDialog({
                     </Label>
                   </div>
                 ))}
+              </div>
+            )}
+          </div>
+
+          <div>
+            <p className="text-sm font-medium mb-2">Image format</p>
+            <RadioGroup
+              value={format}
+              onValueChange={(v) => setFormat(v as ExportImageFormat)}
+              className="grid grid-cols-2 gap-3"
+            >
+              {IMAGE_FORMAT_OPTIONS.map((option) => (
+                <div key={option.id} className="flex items-start space-x-2">
+                  <RadioGroupItem value={option.id} id={`format-${option.id}`} className="mt-0.5" />
+                  <div className="grid gap-0.5 leading-none">
+                    <Label htmlFor={`format-${option.id}`}>{option.label}</Label>
+                    <p className="text-xs text-muted-foreground">{option.note}</p>
+                  </div>
+                </div>
+              ))}
+            </RadioGroup>
+            {format === 'svg' && (
+              <p className="mt-2 text-xs text-muted-foreground">
+                SVG export flattens 3D device renders and videos
+              </p>
+            )}
+            {(format === 'jpeg' || format === 'webp') && (
+              <div className="mt-3 grid gap-1.5">
+                <Label htmlFor="export-quality" className="text-sm">
+                  Quality: {Math.round(quality * 100)}%
+                </Label>
+                <Slider
+                  id="export-quality"
+                  min={10}
+                  max={100}
+                  step={1}
+                  value={[Math.round(quality * 100)]}
+                  onValueChange={(v) => setQuality(v[0] / 100)}
+                />
               </div>
             )}
           </div>

--- a/src/components/open-screenshot-generator/ExportDialog.tsx
+++ b/src/components/open-screenshot-generator/ExportDialog.tsx
@@ -13,6 +13,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import type { Size } from '@/types/artboard';
 import {
   APP_STORE_FORMAT_IDS,
@@ -27,6 +28,8 @@ export interface ExportSelection {
   // (store-correct canvas + matching device mockups), captured, then the
   // canvas is restored — the project itself is never modified.
   generateFormats: DeviceFormat[];
+  // Subset of artboard ids to export; omitted means every artboard.
+  artboardIds?: string[];
 }
 
 // Shared with AppPreviewExportDialog (the video projects' own dialog), which
@@ -57,6 +60,8 @@ interface ExportDialogProps {
   // which App Store sizes are missing.
   currentFormat: DeviceFormat | null;
   currentSize?: Size;
+  // Artboards in canvas order, for the scope checklist.
+  artboards: { id: string; name: string }[];
 }
 
 // Apple's screenshot-specification tiers for the sizes this app can generate
@@ -73,17 +78,22 @@ export function ExportDialog({
   onConfirmExport,
   currentFormat,
   currentSize,
+  artboards,
 }: ExportDialogProps) {
   const [asIs, setAsIs] = useState(true);
   const [generateFormats, setGenerateFormats] = useState<DeviceFormat[]>([]);
+  const [scope, setScope] = useState<'all' | 'pick'>('all');
+  const [checkedIds, setCheckedIds] = useState<string[]>([]);
 
   useEffect(() => {
     // Reset selection whenever the dialog is reopened
     if (isOpen) {
       setAsIs(true);
       setGenerateFormats([]);
+      setScope('all');
+      setCheckedIds(artboards.map((ab) => ab.id));
     }
-  }, [isOpen]);
+  }, [isOpen, artboards]);
 
   const currentPreset = useMemo(
     () => DEVICE_FORMAT_PRESETS.find((p) => p.id === currentFormat),
@@ -114,7 +124,24 @@ export function ExportDialog({
     );
   };
 
+  const toggleArtboard = (id: string) => {
+    setCheckedIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+    );
+  };
+
   const nothingSelected = !asIs && generateFormats.length === 0;
+  const noArtboardsPicked = scope === 'pick' && checkedIds.length === 0;
+
+  const handleConfirm = () => {
+    // Canvas order is preserved by filtering the prop list rather than using
+    // checklist click order, so filename order prefixes stay meaningful.
+    const artboardIds =
+      scope === 'all'
+        ? artboards.map((ab) => ab.id)
+        : artboards.filter((ab) => checkedIds.includes(ab.id)).map((ab) => ab.id);
+    onConfirmExport({ asIs, generateFormats, artboardIds });
+  };
 
   const asIsDescription = currentPreset
     ? `${currentPreset.label} layout${currentSize ? ` — ${currentSize.width}×${currentSize.height}` : ''}`
@@ -135,6 +162,41 @@ export function ExportDialog({
         </DialogHeader>
 
         <div className="grid gap-4 py-2">
+          <div>
+            <p className="text-sm font-medium mb-2">Artboards to export</p>
+            <RadioGroup
+              value={scope}
+              onValueChange={(v) => setScope(v as 'all' | 'pick')}
+              className="grid gap-2"
+            >
+              <div className="flex items-center space-x-2">
+                <RadioGroupItem value="all" id="scope-all" />
+                <Label htmlFor="scope-all">All artboards ({artboards.length})</Label>
+              </div>
+              <div className="flex items-center space-x-2">
+                <RadioGroupItem value="pick" id="scope-pick" />
+                <Label htmlFor="scope-pick">Choose artboards</Label>
+              </div>
+            </RadioGroup>
+            {scope === 'pick' && (
+              // Native overflow div, not ScrollArea: ScrollArea under max-h stops scrolling
+              <div className="mt-2 ml-6 grid max-h-40 gap-2 overflow-y-auto rounded-md border p-3">
+                {artboards.map((ab, index) => (
+                  <div key={ab.id} className="flex items-center space-x-2">
+                    <Checkbox
+                      id={`export-ab-${ab.id}`}
+                      checked={checkedIds.includes(ab.id)}
+                      onCheckedChange={() => toggleArtboard(ab.id)}
+                    />
+                    <Label htmlFor={`export-ab-${ab.id}`} className="font-normal">
+                      {index + 1}. {ab.name}
+                    </Label>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
           <div className="flex items-start space-x-2">
             <Checkbox
               id="export-as-is"
@@ -189,8 +251,8 @@ export function ExportDialog({
             <Button variant="outline">Cancel</Button>
           </DialogClose>
           <Button
-            onClick={() => onConfirmExport({ asIs, generateFormats })}
-            disabled={nothingSelected}
+            onClick={handleConfirm}
+            disabled={nothingSelected || noArtboardsPicked}
           >
             Export
           </Button>

--- a/src/components/open-screenshot-generator/LayersPanel.tsx
+++ b/src/components/open-screenshot-generator/LayersPanel.tsx
@@ -12,8 +12,12 @@ import { cn } from '@/lib/utils';
 // whatever height the dock gives it.
 interface LayersPanelProps {
   elements: ArtboardElement[];
-  selectedElementId: string | null;
-  onSelectElement: (elementId: string) => void;
+  // All selected element ids on this artboard; the last one is the "primary"
+  // selection used for scroll-into-view.
+  selectedElementIds: string[];
+  // Plain click selects the element alone; { additive: true } (Shift/Ctrl/Cmd
+  // click) toggles it in/out of the selection.
+  onSelectElement: (elementId: string, modifiers?: { additive?: boolean }) => void;
   onMoveElementLayer: (elementId: string, direction: 'up' | 'down') => void;
   onDeleteElement: (elementId: string) => void;
   onRenameElement: (elementId: string, newName: string) => void;
@@ -78,17 +82,18 @@ const getElementLabel = (element: ArtboardElement): string => {
     return label;
 };
 
-export function LayersPanel({ elements, selectedElementId, onSelectElement, onMoveElementLayer, onDeleteElement, onRenameElement, activeArtboardName }: LayersPanelProps) {
+export function LayersPanel({ elements, selectedElementIds, onSelectElement, onMoveElementLayer, onDeleteElement, onRenameElement, activeArtboardName }: LayersPanelProps) {
   const [editingElementId, setEditingElementId] = useState<string | null>(null);
   const [editingName, setEditingName] = useState<string>('');
   const inputRef = useRef<HTMLInputElement>(null);
   const selectedRowRef = useRef<HTMLDivElement>(null);
+  const primarySelectedElementId = selectedElementIds.length > 0 ? selectedElementIds[selectedElementIds.length - 1] : null;
 
   // Keep the selected row visible when selection happens on the canvas;
   // 'nearest' makes this a no-op if the row is already in view.
   useEffect(() => {
     selectedRowRef.current?.scrollIntoView({ block: 'nearest' });
-  }, [selectedElementId]);
+  }, [primarySelectedElementId]);
 
   // Focus input when editing starts
   useEffect(() => {
@@ -135,6 +140,11 @@ export function LayersPanel({ elements, selectedElementId, onSelectElement, onMo
         <span className="truncate text-sm font-semibold" title={activeArtboardName}>
           {activeArtboardName ? `Layers: ${activeArtboardName}` : 'Layers'}
         </span>
+        {selectedElementIds.length > 1 && (
+          <span className="ml-auto shrink-0 rounded-full border px-1.5 text-[11px] tabular-nums text-muted-foreground">
+            {selectedElementIds.length} selected
+          </span>
+        )}
       </div>
       {!activeArtboardName ? (
         <div className="p-3 text-sm text-muted-foreground">Select an artboard to see its layers.</div>
@@ -149,10 +159,10 @@ export function LayersPanel({ elements, selectedElementId, onSelectElement, onMo
               {reversedElements.map((element, index) => (
                 <div
                   key={element.id}
-                  ref={element.id === selectedElementId ? selectedRowRef : undefined}
+                  ref={element.id === primarySelectedElementId ? selectedRowRef : undefined}
                   className={cn(
                     "flex items-center w-full justify-start p-1 rounded-md text-sm",
-                    element.id === selectedElementId ? "bg-accent text-accent-foreground" : "hover:bg-accent/50"
+                    selectedElementIds.includes(element.id) ? "bg-accent text-accent-foreground" : "hover:bg-accent/50"
                   )}
                 >
                   {editingElementId === element.id ? (
@@ -172,7 +182,7 @@ export function LayersPanel({ elements, selectedElementId, onSelectElement, onMo
                     <Button
                       variant="ghost"
                       className="flex-grow justify-start p-1 h-auto text-left items-center hover:bg-transparent focus-visible:ring-0 max-w-[160px]"
-                      onClick={() => onSelectElement(element.id)}
+                      onClick={(e) => onSelectElement(element.id, { additive: e.shiftKey || e.ctrlKey || e.metaKey })}
                       onDoubleClick={() => handleDoubleClick(element)}
                       title={`Double-click to rename "${getElementLabel(element)}"`}
                     >

--- a/src/components/open-screenshot-generator/OpenScreenshotGeneratorLayout.tsx
+++ b/src/components/open-screenshot-generator/OpenScreenshotGeneratorLayout.tsx
@@ -120,10 +120,10 @@ function calculateArtboardPositions(artboards: ArtboardState[]): ArtboardState[]
   return artboards.map((ab, index) => {
     const newPosition = { x: currentX, y: ARTBOARD_MARGIN };
     console.log(`Artboard ${index}: size=${ab.size.width}x${ab.size.height}, position=${newPosition.x},${newPosition.y}`);
-    
+
     // Calculate next position with reduced margin
     currentX += (ab.size.width * DISPLAY_SCALE_FACTOR) + ARTBOARD_MARGIN;
-    
+
     return { ...ab, position: newPosition };
   });
 }
@@ -1252,12 +1252,24 @@ export function OpenScreenshotGeneratorLayout() {
   // live DOM node (matched by artboard id). The list must be what the canvas
   // is currently rendering — for generated formats, handleConfirmExport
   // swaps the converted list in first and restores afterwards.
-  const captureArtboards = async (list: ArtboardState[], exportDir?: string | null) => {
+  const captureArtboards = async (
+    list: ArtboardState[],
+    exportDir?: string | null,
+    options: {
+      // Restrict the capture to these artboard ids; omitted captures the whole
+      // list. Skipped boards still consume their loop index, so filename
+      // order prefixes match the on-canvas positions.
+      selectedIds?: ReadonlySet<string>;
+    } = {},
+  ) => {
+    const { selectedIds } = options;
     // Array order matches canvas order (calculateArtboardPositions lays boards
     // out left-to-right by index), so the loop index is the on-canvas position.
     const orderPadWidth = Math.max(2, String(list.length).length);
 
     for (const [index, artboard] of list.entries()) {
+      if (selectedIds && !selectedIds.has(artboard.id)) continue;
+
       // Find the DOM element for the artboard content
       const artboardElement = document.querySelector(`[data-artboard-dom-id="${artboard.id}"]`) as HTMLElement | null;
 
@@ -1276,10 +1288,10 @@ export function OpenScreenshotGeneratorLayout() {
         const originalTransform = artboardElement.style.transform;
         const originalWidth = artboardElement.style.width;
         const originalHeight = artboardElement.style.height;
-        
+
         // Remove scale transform for export
         artboardElement.style.transform = 'scale(1)';
-        
+
         // Use html-to-image to capture the artboard at exact specified dimensions
         const { backgroundColor, backgroundImage } = artboardBackground(artboard);
         const imageDataUrl = await toPng(artboardElement, {
@@ -1300,7 +1312,7 @@ export function OpenScreenshotGeneratorLayout() {
             backgroundImage,
           }
         });
-        
+
         // Restore original styling after export
         artboardElement.style.transform = originalTransform;
         artboardElement.style.width = originalWidth;
@@ -1358,16 +1370,19 @@ export function OpenScreenshotGeneratorLayout() {
   // engine as the Devices menu, rendered, captured, then the original state
   // is restored — plain setArtboards keeps history and the saved project
   // untouched, so this can never corrupt the user's work.
-  const handleConfirmExport = async ({ asIs, generateFormats }: ExportSelection) => {
+  const handleConfirmExport = async ({ asIs, generateFormats, artboardIds }: ExportSelection) => {
     setIsExportDialogOpen(false);
 
     const original = artboards;
+    const selectedIds: ReadonlySet<string> = new Set(artboardIds ?? original.map((ab) => ab.id));
+    const selectedCount = original.reduce((n, ab) => n + (selectedIds.has(ab.id) ? 1 : 0), 0);
+    if (selectedCount === 0) return; // the dialog blocks this; never capture nothing
 
     // Desktop batch exports pick one destination folder up front instead of
     // opening a native save dialog per file; cancelling the picker aborts
     // the whole export. Single-file exports keep the per-file save dialog.
     let exportDir: string | null | undefined;
-    const totalFiles = (asIs ? original.length : 0) + generateFormats.length * original.length;
+    const totalFiles = (asIs ? selectedCount : 0) + generateFormats.length * selectedCount;
     if (isTauri() && totalFiles > 1) {
       exportDir = await pickExportDirectory('Choose a folder for the exported artboards');
       if (exportDir === null) return;
@@ -1376,7 +1391,7 @@ export function OpenScreenshotGeneratorLayout() {
     trackExportPng({
       mode: generateFormats.length > 0 ? 'app_store' : 'as_is',
       formats: generateFormats,
-      artboardCount: original.length,
+      artboardCount: selectedCount,
       fileCount: totalFiles,
     });
 
@@ -1394,7 +1409,7 @@ export function OpenScreenshotGeneratorLayout() {
       window.dispatchEvent(new CustomEvent('artboard:export', { detail: { phase: 'begin' } }));
       await new Promise((resolve) => setTimeout(resolve, 100));
       try {
-        await captureArtboards(list, exportDir);
+        await captureArtboards(list, exportDir, { selectedIds });
       } finally {
         window.dispatchEvent(new CustomEvent('artboard:export', { detail: { phase: 'end' } }));
       }
@@ -1452,6 +1467,14 @@ export function OpenScreenshotGeneratorLayout() {
   // An App Preview project is one that carries recording mockups, recordings,
   // gesture hints or animations — it gets the video export dialog.
   const isAppPreviewProject = useMemo(() => projectHasVideoContent(artboards), [artboards]);
+
+  // Stable identity for the ExportDialog scope checklist: a fresh .map on
+  // every render would retrigger the dialog's reset-on-open effect and wipe
+  // the user's picks mid-interaction.
+  const exportDialogBoards = useMemo(
+    () => artboards.map((ab) => ({ id: ab.id, name: ab.name })),
+    [artboards]
+  );
 
   const videoBoards = artboards.filter((ab) => {
     const info = videoInfos[ab.id];
@@ -3486,6 +3509,7 @@ const generateRandomProjectName = (): string => {
               onConfirmExport={handleConfirmExport}
               currentFormat={activeDeviceFormat}
               currentSize={artboards[0]?.size}
+              artboards={exportDialogBoards}
             />
           )}
 

--- a/src/components/open-screenshot-generator/OpenScreenshotGeneratorLayout.tsx
+++ b/src/components/open-screenshot-generator/OpenScreenshotGeneratorLayout.tsx
@@ -42,6 +42,8 @@ import {
 } from '@/lib/mcp/desktopMcpServer';
 import { McpServerStatus } from './McpServerStatus';
 import { agentUsableTemplates } from '@/lib/ai/templateCatalog';
+import { autoPlaceScreenshotsPlan, buildProjectFromPlan } from '@/lib/ai/buildProjectFromPlan';
+import { readScreenshotFile, type UploadedScreenshot } from '@/lib/ai/imageUtils';
 import { loadProjectTemplates } from '@/services/projectService';
 import { TEMPLATE_CATEGORIES } from '@/lib/templateCategories';
 import { convertArtboardsToFormat, detectArtboardsFormat, swapDeviceInElements, scaleElementsToCanvas, DEVICE_FORMAT_PRESETS, type DeviceFormatPreset } from '@/lib/deviceRegistry';
@@ -51,10 +53,11 @@ import { trackTemplateSelected, trackDeviceFormatSelected, trackExportPng, track
 import { AgentPromoBanner } from './start/AgentPromoBanner';
 import { BlankCanvasCard } from './start/BlankCanvasCard';
 import { AgentStartScreen } from './start/AgentStartScreen';
+import { TemplateProposalPicker } from './start/TemplateProposalPicker';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { ChevronLeftIcon, InfoIcon, PanelRightCloseIcon, PanelRightOpenIcon, SearchIcon, UserIcon, ZoomInIcon, ZoomOutIcon } from 'lucide-react';
+import { ChevronLeftIcon, InfoIcon, Loader2Icon, PanelRightCloseIcon, PanelRightOpenIcon, SearchIcon, UserIcon, ZoomInIcon, ZoomOutIcon } from 'lucide-react';
 import { AccountDialog } from './account/AccountDialog';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import {
@@ -477,6 +480,12 @@ export function OpenScreenshotGeneratorLayout() {
   const [videoProgress, setVideoProgress] = useState<VideoExportProgress | null>(null);
   const videoExportAbortRef = useRef<AbortController | null>(null);
   const [isAboutOpen, setIsAboutOpen] = useState(false);
+  // Bulk OS drop onto an empty canvas: the dropped images are read into
+  // screenshots, then the template proposal dialog offers to auto-build a
+  // project from them (deterministic, no AI).
+  const [bulkDropDialogOpen, setBulkDropDialogOpen] = useState(false);
+  const [bulkDropScreenshots, setBulkDropScreenshots] = useState<UploadedScreenshot[]>([]);
+  const [bulkDropReading, setBulkDropReading] = useState(false);
   // Cloud account (Bring-Your-Own-Storage). `accountHint` is set when the
   // dialog is opened from a gated action so it can explain why it appeared.
   const [isAccountOpen, setIsAccountOpen] = useState(false);
@@ -1143,10 +1152,65 @@ export function OpenScreenshotGeneratorLayout() {
     } catch (error) {
       console.error("Error creating project from template:", error);
       setIsLoadingTemplate(false); // Reset loading flag on error
-      toast({ 
-        title: "Creation Failed", 
-        description: "Failed to create project from template.", 
-        variant: "destructive" 
+      toast({
+        title: "Creation Failed",
+        description: "Failed to create project from template.",
+        variant: "destructive"
+      });
+    }
+  };
+
+  // Image files dropped onto a canvas with no artboards: read them, then offer
+  // to auto-build a project from a ranked template pick (no AI involved).
+  const MAX_BULK_DROP_SCREENSHOTS = 12;
+  const handleImagesDroppedOnEmptyCanvas = async (files: File[]) => {
+    const accepted = files.slice(0, MAX_BULK_DROP_SCREENSHOTS);
+    // The start dialog can be up over the empty canvas; take it down directly
+    // (NOT through its onOpenChange, which would auto-create a blank project
+    // under the proposal). If the user dismisses the proposal they can reopen
+    // the start dialog from the toolbar's template button.
+    setIsTemplateSelectorOpen(false);
+    setBulkDropDialogOpen(true);
+    setBulkDropReading(true);
+    setBulkDropScreenshots([]);
+    try {
+      const shots = await Promise.all(accepted.map(readScreenshotFile));
+      setBulkDropScreenshots(shots);
+      if (files.length > accepted.length) {
+        toast({
+          title: "Some images skipped",
+          description: `Only the first ${accepted.length} images were used.`,
+        });
+      }
+    } catch {
+      setBulkDropDialogOpen(false);
+      toast({
+        title: "Could not read those images",
+        description: "Use PNG, JPEG, WebP, GIF or SVG files.",
+        variant: "destructive",
+      });
+    } finally {
+      setBulkDropReading(false);
+    }
+  };
+
+  // The picked template becomes a project through the same handoff the AI
+  // agent uses (auto-place plan -> build -> handleSelectTemplate).
+  const handleBulkDropPick = async (template: Project) => {
+    try {
+      const built = buildProjectFromPlan(
+        autoPlaceScreenshotsPlan(template),
+        bulkDropScreenshots,
+        agentUsableTemplates(availableProjects)
+      );
+      setBulkDropDialogOpen(false);
+      setBulkDropScreenshots([]);
+      await handleSelectTemplate(built.project, { nameOverride: built.project.name });
+    } catch (error) {
+      toast({
+        title: "Could not build the project",
+        description: error instanceof Error ? error.message : "Something went wrong.",
+        variant: "destructive",
       });
     }
   };
@@ -3411,6 +3475,7 @@ const generateRandomProjectName = (): string => {
                 onTranslateArtboard={handleTranslateArtboard}
                 activeTool={activeTool}
                 isLoading={loadPhase === 'project' || (!!activeProjectId && artboards.length === 0)}
+                onImagesDroppedOnEmptyCanvas={(files) => void handleImagesDroppedOnEmptyCanvas(files)}
               />
 
               {/* Floating zoom control (bottom-left of canvas) */}
@@ -3625,6 +3690,37 @@ const generateRandomProjectName = (): string => {
             hint={accountHint}
             onOpenProject={handleOpenFromAccount}
           />
+
+          {/* Bulk drop onto an empty canvas: rank templates by device-slot fit
+              and build the picked one with the screenshots auto-placed. */}
+          <Dialog
+            open={bulkDropDialogOpen}
+            onOpenChange={(open) => {
+              setBulkDropDialogOpen(open);
+              if (!open) setBulkDropScreenshots([]);
+            }}
+          >
+            <DialogContent className="max-w-3xl">
+              <DialogHeader>
+                <DialogTitle className="sr-only">Pick a template</DialogTitle>
+                <DialogDescription className="sr-only">
+                  We place your dropped screenshots in the device frames of the template you pick.
+                </DialogDescription>
+              </DialogHeader>
+              {bulkDropReading ? (
+                <div className="flex items-center justify-center gap-2 py-10 text-sm text-muted-foreground">
+                  <Loader2Icon className="h-4 w-4 animate-spin" />
+                  Reading your images...
+                </div>
+              ) : (
+                <TemplateProposalPicker
+                  templates={availableProjects}
+                  screenshots={bulkDropScreenshots}
+                  onPick={(template) => void handleBulkDropPick(template)}
+                />
+              )}
+            </DialogContent>
+          </Dialog>
 
           <TranslateDialog
             isOpen={isTranslateDialogOpen}

--- a/src/components/open-screenshot-generator/OpenScreenshotGeneratorLayout.tsx
+++ b/src/components/open-screenshot-generator/OpenScreenshotGeneratorLayout.tsx
@@ -45,6 +45,7 @@ import { agentUsableTemplates } from '@/lib/ai/templateCatalog';
 import { loadProjectTemplates } from '@/services/projectService';
 import { TEMPLATE_CATEGORIES } from '@/lib/templateCategories';
 import { convertArtboardsToFormat, detectArtboardsFormat, swapDeviceInElements, scaleElementsToCanvas, DEVICE_FORMAT_PRESETS, type DeviceFormatPreset } from '@/lib/deviceRegistry';
+import { alignElementsWithinArtboard, selectionBounds, type ElementAlignment } from '@/lib/elementAlignment';
 import { trackTemplateSelected, trackDeviceFormatSelected, trackExportPng, trackExportVideo, trackExportJson } from '@/lib/analytics';
 
 import { AgentPromoBanner } from './start/AgentPromoBanner';
@@ -372,7 +373,7 @@ export function OpenScreenshotGeneratorLayout() {
   // Latest design-tool API for the desktop MCP server; assigned each render and
   // read per request by the bridge (see the block above the render return).
   const mcpApiRef = useRef<McpDesignApi | null>(null);
-  const [selectedElementIdOnActiveArtboard, setSelectedElementIdOnActiveArtboard] = useState<string | null>(null);
+  const [selectedElementIdsOnActiveArtboard, setSelectedElementIdsOnActiveArtboard] = useState<string[]>([]);
   // Custom right-click menu over the canvas. pastePoint is the click location
   // in artboard coordinates so Paste can drop the element under the cursor.
   const [contextMenu, setContextMenu] = useState<{
@@ -414,7 +415,14 @@ export function OpenScreenshotGeneratorLayout() {
       disposeStatus();
     };
   }, [toast]);
-  const [selectedElementDetails, setSelectedElementDetails] = useState<ArtboardElement | null>(null);
+  // The element the properties panel edits, derived from the selection: only
+  // a single selection exposes per-property editing; a multi-selection shows
+  // the panel's multi-select state instead.
+  const selectedElementDetails = useMemo(() => {
+    if (!activeArtboardId || selectedElementIdsOnActiveArtboard.length !== 1) return null;
+    const activeAb = artboards.find((ab) => ab.id === activeArtboardId);
+    return activeAb?.elements.find((el) => el.id === selectedElementIdsOnActiveArtboard[0]) ?? null;
+  }, [activeArtboardId, selectedElementIdsOnActiveArtboard, artboards]);
   const [activeTool, setActiveTool] = useState<'select' | 'pan'>('select');
   // Seed from the URL so the project-loading and selector effects see the real
   // active id on the first render instead of a transient null (which would force
@@ -501,7 +509,7 @@ export function OpenScreenshotGeneratorLayout() {
     setIsRightDockOpen(open);
     try { window.localStorage.setItem(RIGHT_DOCK_OPEN_KEY, open ? '1' : '0'); } catch {}
   };
-  const { clipboardItem, copyToClipboard } = useClipboard();
+  const { clipboardItems, copyElementsToClipboard } = useClipboard();
   const router = useRouter();
   const searchParams = useSearchParams();
   
@@ -605,7 +613,7 @@ export function OpenScreenshotGeneratorLayout() {
             // edit (matches loadProjectFromData, the click-a-template path). Without
             // this, refreshing into ?projectId left nothing selected.
             setActiveArtboardId(projectData.length > 0 ? projectData[0].id : null);
-            setSelectedElementIdOnActiveArtboard(null);
+            setSelectedElementIdsOnActiveArtboard([]);
             setIsTemplateSelectorOpen(false); // Close template selector if a project is loaded
           } else {
             console.warn(`Project with ID ${activeProjectId} not found.`);
@@ -714,34 +722,28 @@ export function OpenScreenshotGeneratorLayout() {
     };
     if (activeArtboardId && !repositionedArtboards.find(ab => ab.id === activeArtboardId)) {
         setActiveArtboardId(null);
-        setSelectedElementIdOnActiveArtboard(null);
+        setSelectedElementIdsOnActiveArtboard([]);
     }
-    if (activeArtboardId && selectedElementIdOnActiveArtboard) {
+    if (activeArtboardId && selectedElementIdsOnActiveArtboard.length > 0) {
         const currentAb = repositionedArtboards.find(ab => ab.id === activeArtboardId);
-        if (currentAb && !currentAb.elements.find(el => el.id === selectedElementIdOnActiveArtboard)) {
-            setSelectedElementIdOnActiveArtboard(null);
+        if (currentAb) {
+            // Prune ids the update removed (deletions, device swaps) so the
+            // selection never points at elements that no longer exist.
+            const surviving = selectedElementIdsOnActiveArtboard.filter(id =>
+                currentAb.elements.some(el => el.id === id)
+            );
+            if (surviving.length !== selectedElementIdsOnActiveArtboard.length) {
+                setSelectedElementIdsOnActiveArtboard(surviving);
+            }
         }
     }
     saveProject(); // Call the async save function
     pushToHistory(repositionedArtboards);
-  }, [activeArtboardId, selectedElementIdOnActiveArtboard, activeProjectId, currentProjectName, history, historyIndex, setActiveProjectId]);
-
-  useEffect(() => {
-    if (activeArtboardId && selectedElementIdOnActiveArtboard) {
-      const activeAb = artboards.find(ab => ab.id === activeArtboardId);
-      if (activeAb) {
-        const element = activeAb.elements.find(el => el.id === selectedElementIdOnActiveArtboard);
-        setSelectedElementDetails(element || null);
-      } else {
-        setSelectedElementDetails(null);
-      }
-    } else {
-      setSelectedElementDetails(null);
-    }
-  }, [activeArtboardId, selectedElementIdOnActiveArtboard, artboards]);
+  }, [activeArtboardId, selectedElementIdsOnActiveArtboard, activeProjectId, currentProjectName, history, historyIndex, setActiveProjectId]);
 
   const handleUpdateSelectedElement = (updates: Partial<ArtboardElement>) => {
-    if (!activeArtboardId || !selectedElementIdOnActiveArtboard) return;
+    if (!activeArtboardId || selectedElementIdsOnActiveArtboard.length !== 1) return;
+    const targetElementId = selectedElementIdsOnActiveArtboard[0];
 
     const updatedArtboards = artboards.map(ab => {
       if (ab.id === activeArtboardId) {
@@ -750,7 +752,7 @@ export function OpenScreenshotGeneratorLayout() {
         // re-fit to the new device's screen rect and corner radius.
         const deviceTarget = (updates as Partial<DeviceFrameElementProps>).deviceType;
         if (deviceTarget) {
-          const swappedElements = swapDeviceInElements(ab.elements, selectedElementIdOnActiveArtboard, deviceTarget);
+          const swappedElements = swapDeviceInElements(ab.elements, targetElementId, deviceTarget);
           if (swappedElements) {
             return { ...ab, elements: swappedElements };
           }
@@ -758,7 +760,7 @@ export function OpenScreenshotGeneratorLayout() {
         return {
           ...ab,
           elements: ab.elements.map(el =>
-            el.id === selectedElementIdOnActiveArtboard ? { ...el, ...updates } as ArtboardElement : el
+            el.id === targetElementId ? { ...el, ...updates } as ArtboardElement : el
           ),
         };
       }
@@ -867,7 +869,7 @@ export function OpenScreenshotGeneratorLayout() {
     if (artboardComponent && typeof artboardComponent.addElement === 'function') {
       const newElementId = artboardComponent.addElement(type, subType, dropPosition, styleProps);
       if (newElementId) {
-        setSelectedElementIdOnActiveArtboard(newElementId);
+        setSelectedElementIdsOnActiveArtboard([newElementId]);
         setActiveArtboardId(artboardId);
       }
     } else {
@@ -911,7 +913,7 @@ export function OpenScreenshotGeneratorLayout() {
     const newArtboards = [...artboards, newArtboard];
     handleArtboardsUpdate(newArtboards);
     setActiveArtboardId(newArtboard.id);
-    setSelectedElementIdOnActiveArtboard(null);
+    setSelectedElementIdsOnActiveArtboard([]);
     toast({ title: "Artboard Created", description: `Artboard "${newArtboard.name}" added.` });
   };
 
@@ -941,7 +943,7 @@ export function OpenScreenshotGeneratorLayout() {
     
     handleArtboardsUpdate(newArtboardsArray);
     setActiveArtboardId(newArtboard.id);
-    setSelectedElementIdOnActiveArtboard(null);
+    setSelectedElementIdsOnActiveArtboard([]);
     toast({ title: "Artboard Added", description: `New artboard added after "${artboards[currentIndex]?.name || 'selected'}".` });
   };
   
@@ -979,7 +981,7 @@ export function OpenScreenshotGeneratorLayout() {
 
     if (activeArtboardId === artboardId) {
       setActiveArtboardId(newArtboardsArray.length > 0 ? newArtboardsArray[0].id : null);
-      setSelectedElementIdOnActiveArtboard(null);
+      setSelectedElementIdsOnActiveArtboard([]);
     }
     toast({ title: "Artboard Deleted", description: `Artboard "${artboardToDelete.name}" deleted.` });
   };
@@ -1573,7 +1575,7 @@ export function OpenScreenshotGeneratorLayout() {
        if (activeArtboardId && !prevState.find((ab: ArtboardState) => ab.id === activeArtboardId)) {
         setActiveArtboardId(prevState.length > 0 ? prevState[0].id : null);
       }
-      setSelectedElementIdOnActiveArtboard(null);
+      setSelectedElementIdsOnActiveArtboard([]);
     }
   }, [historyIndex, history, activeArtboardId]);
 
@@ -1586,31 +1588,31 @@ export function OpenScreenshotGeneratorLayout() {
        if (activeArtboardId && !nextState.find((ab: ArtboardState) => ab.id === activeArtboardId)) {
         setActiveArtboardId(nextState.length > 0 ? nextState[0].id : null);
       }
-      setSelectedElementIdOnActiveArtboard(null);
+      setSelectedElementIdsOnActiveArtboard([]);
     }
   }, [historyIndex, history, activeArtboardId, history.length]);
 
-  // Fix the handleDeleteSelected function to properly handle deletion
+  // Delete the whole selection on the active artboard in a single commit, or
+  // the active artboard itself when no element is selected.
   const handleDeleteSelected = useCallback(() => { 
-    if (activeArtboardId && selectedElementIdOnActiveArtboard) {
-      // Find the active artboard
+    if (activeArtboardId && selectedElementIdsOnActiveArtboard.length > 0) {
       const activeArtboard = artboards.find(ab => ab.id === activeArtboardId);
       if (activeArtboard) {
-        // Find the element to delete
-        const elementExists = activeArtboard.elements.some(
-          el => el.id === selectedElementIdOnActiveArtboard
-        );
+        const wanted = new Set(selectedElementIdsOnActiveArtboard);
+        const remaining = activeArtboard.elements.filter(el => !wanted.has(el.id));
+        const removedCount = activeArtboard.elements.length - remaining.length;
 
-        // If element exists, delete it
-        if (elementExists) {
-          const artboardComponent = artboardRefs.current[activeArtboardId];
-          if(artboardComponent && artboardComponent.deleteElementByIdG) {
-            artboardComponent.deleteElementByIdG(selectedElementIdOnActiveArtboard);
-            setSelectedElementIdOnActiveArtboard(null);
-            toast({ title: "Element Deleted", description: "Element was removed from the artboard." });
-          } else {
-            toast({title: "Cannot Delete Element", description: "Artboard component reference not found.", variant: "destructive"});
-          }
+        if (removedCount > 0) {
+          handleArtboardsUpdate(artboards.map(ab =>
+            ab.id === activeArtboardId ? { ...ab, elements: remaining } : ab
+          ));
+          setSelectedElementIdsOnActiveArtboard([]);
+          toast({
+            title: removedCount === 1 ? "Element Deleted" : "Elements Deleted",
+            description: removedCount === 1
+              ? "Element was removed from the artboard."
+              : `${removedCount} elements were removed from the artboard.`,
+          });
         } else {
           toast({title: "Cannot Delete Element", description: "Selected element not found in artboard.", variant: "destructive"});
         }
@@ -1620,9 +1622,32 @@ export function OpenScreenshotGeneratorLayout() {
     } else {
       toast({title: "Cannot Delete", description: "No artboard or element selected.", variant: "destructive"});
     }
-  }, [activeArtboardId, selectedElementIdOnActiveArtboard, artboards, toast]);
+  }, [activeArtboardId, selectedElementIdsOnActiveArtboard, artboards, toast, handleArtboardsUpdate]);
 
-  // Add keyboard event handlers for delete, undo, and redo
+  // Arrow-key nudging: arrows move the selection 1 artboard px, Shift+arrows
+  // 10 px. One history commit per press via handleArtboardsUpdate.
+  const handleNudgeSelected = useCallback((dx: number, dy: number) => {
+    if (!activeArtboardId || selectedElementIdsOnActiveArtboard.length === 0) return;
+    const activeArtboard = artboards.find(ab => ab.id === activeArtboardId);
+    if (!activeArtboard) return;
+    const wanted = new Set(selectedElementIdsOnActiveArtboard);
+    if (!activeArtboard.elements.some(el => wanted.has(el.id))) return;
+    handleArtboardsUpdate(artboards.map(ab =>
+      ab.id !== activeArtboardId
+        ? ab
+        : {
+            ...ab,
+            elements: ab.elements.map(el =>
+              wanted.has(el.id)
+                ? ({ ...el, position: { x: el.position.x + dx, y: el.position.y + dy } } as ArtboardElement)
+                : el
+            ),
+          }
+    ));
+  }, [activeArtboardId, selectedElementIdsOnActiveArtboard, artboards, handleArtboardsUpdate]);
+
+  // Add keyboard event handlers for delete, undo, redo, clipboard, selection
+  // and nudging. This is the ONLY keydown effect; keep every shortcut here.
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       // Preview mode has its own keyboard handling
@@ -1636,10 +1661,12 @@ export function OpenScreenshotGeneratorLayout() {
         return;
       }
 
+      const hasElementSelection = selectedElementIdsOnActiveArtboard.length > 0;
+
       // Copy: Ctrl+C or Cmd+C
       if ((e.ctrlKey || e.metaKey) && e.key === 'c') {
         e.preventDefault();
-        if (activeArtboardId && selectedElementIdOnActiveArtboard) {
+        if (activeArtboardId && hasElementSelection) {
           handleCopyElement();
         }
       }
@@ -1647,9 +1674,34 @@ export function OpenScreenshotGeneratorLayout() {
       // Paste: Ctrl+V or Cmd+V
       if ((e.ctrlKey || e.metaKey) && e.key === 'v') {
         e.preventDefault();
-        if (clipboardItem) {
+        if (clipboardItems.length > 0) {
           handlePasteElement();
         }
+      }
+
+      // Select all on the active artboard: Ctrl+A or Cmd+A
+      if ((e.ctrlKey || e.metaKey) && (e.key === 'a' || e.key === 'A')) {
+        if (activeArtboardId) {
+          e.preventDefault();
+          const activeAb = artboards.find(ab => ab.id === activeArtboardId);
+          if (activeAb) {
+            setSelectedElementIdsOnActiveArtboard(activeAb.elements.map(el => el.id));
+          }
+        }
+      }
+
+      // Escape clears the element selection
+      if (e.key === 'Escape' && hasElementSelection) {
+        setSelectedElementIdsOnActiveArtboard([]);
+      }
+
+      // Nudge: arrows move the selection 1 artboard px, Shift+arrows 10 px
+      if (e.key.startsWith('Arrow') && activeArtboardId && hasElementSelection) {
+        e.preventDefault();
+        const step = e.shiftKey ? 10 : 1;
+        const dx = e.key === 'ArrowLeft' ? -step : e.key === 'ArrowRight' ? step : 0;
+        const dy = e.key === 'ArrowUp' ? -step : e.key === 'ArrowDown' ? step : 0;
+        handleNudgeSelected(dx, dy);
       }
 
       // Delete key for element or artboard deletion
@@ -1692,21 +1744,35 @@ export function OpenScreenshotGeneratorLayout() {
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
     };
-  }, [handleDeleteSelected, handleUndo, handleRedo, historyIndex, history.length, activeArtboardId, selectedElementIdOnActiveArtboard, clipboardItem, setActiveTool, isPreviewOpen]);
+  }, [handleDeleteSelected, handleNudgeSelected, handleUndo, handleRedo, historyIndex, history.length, activeArtboardId, selectedElementIdsOnActiveArtboard, clipboardItems, artboards, setActiveTool, isPreviewOpen]);
 
   const handleArtboardSelection = (artboardId: string | null) => {
     setActiveArtboardId(artboardId);
-    if (artboardId !== activeProjectId) {
-        setSelectedElementIdOnActiveArtboard(null);
+    if (artboardId !== activeArtboardId) {
+        setSelectedElementIdsOnActiveArtboard([]);
     }
   }
 
-  const handleElementSelectionOnArtboard = (elementId: string | null) => {
-    setSelectedElementIdOnActiveArtboard(elementId);
+  // Single-id selection entry point (canvas click, layers panel). A plain
+  // call selects just that element (or clears when null); { additive: true }
+  // toggles it in/out of the current selection (Shift/Ctrl/Cmd click).
+  const handleElementSelectionOnArtboard = (elementId: string | null, modifiers?: { additive?: boolean }) => {
+    setSelectedElementIdsOnActiveArtboard((prev) => {
+      if (elementId === null) return [];
+      if (modifiers?.additive) {
+        return prev.includes(elementId) ? prev.filter((id) => id !== elementId) : [...prev, elementId];
+      }
+      return [elementId];
+    });
   }
 
-  const handleSelectElementFromLayerPanel = (elementId: string) => {
-    setSelectedElementIdOnActiveArtboard(elementId);
+  // Bulk selection entry point (marquee, select-all, paste).
+  const handleElementsSelectionOnArtboard = (elementIds: string[]) => {
+    setSelectedElementIdsOnActiveArtboard(elementIds);
+  }
+
+  const handleSelectElementFromLayerPanel = (elementId: string, modifiers?: { additive?: boolean }) => {
+    handleElementSelectionOnArtboard(elementId, modifiers);
   };
 
   // Add handler for deleting element from layers panel
@@ -1715,7 +1781,7 @@ export function OpenScreenshotGeneratorLayout() {
       const artboardComponent = artboardRefs.current[activeArtboardId];
       if (artboardComponent && artboardComponent.deleteElementByIdG) {
         artboardComponent.deleteElementByIdG(elementId);
-        setSelectedElementIdOnActiveArtboard(null);
+        setSelectedElementIdsOnActiveArtboard((prev) => prev.filter((id) => id !== elementId));
         toast({ title: "Element Deleted", description: "Element was removed from the artboard." });
       } else {
         toast({ title: "Cannot Delete Element", description: "Artboard component reference not found.", variant: "destructive" });
@@ -1752,6 +1818,21 @@ export function OpenScreenshotGeneratorLayout() {
     });
     handleArtboardsUpdate(updatedArtboards); // Use handleArtboardsUpdate to ensure history and positioning
   };
+
+  // Alignment controls in the properties panel. A single element aligns
+  // inside the artboard bounds; a multi-selection aligns inside its own
+  // bounding box, with distribute available at 3+ elements. One commit per
+  // click via handleArtboardsUpdate, so undo restores the previous layout.
+  const handleAlignElements = useCallback((mode: ElementAlignment) => {
+    if (!activeArtboardId || selectedElementIdsOnActiveArtboard.length === 0) return;
+    const activeAb = artboards.find(ab => ab.id === activeArtboardId);
+    if (!activeAb) return;
+    const alignedElements = alignElementsWithinArtboard(activeAb, selectedElementIdsOnActiveArtboard, mode);
+    if (!alignedElements) return; // nothing would move; skip the history entry
+    handleArtboardsUpdate(artboards.map(ab =>
+      ab.id === activeArtboardId ? { ...ab, elements: alignedElements } : ab
+    ));
+  }, [activeArtboardId, selectedElementIdsOnActiveArtboard, artboards, handleArtboardsUpdate]);
 
   // Applies a new canvas size to every artboard. With `scaleContent` (the
   // Canvas Size dialog's default) each artboard's elements are uniformly
@@ -2052,54 +2133,69 @@ export function OpenScreenshotGeneratorLayout() {
   const activeArtboardName = activeArtboard ? activeArtboard.name : undefined;
 
 
-  // Define the copy element handler. Explicit ids come from the context menu
-  // (copy exactly what was right-clicked); the keyboard shortcut passes none
-  // and falls back to the current selection.
+  // Define the copy element handler. Explicit ids come from the context menu:
+  // copying a right-clicked element that is part of the current selection
+  // copies the whole set, otherwise just that element. The keyboard shortcut
+  // passes no ids and copies the current selection.
   const handleCopyElement = (targetArtboardId?: string | null, targetElementId?: string | null) => {
     const artboardId = targetArtboardId ?? activeArtboardId;
-    const elementId = targetElementId ?? selectedElementIdOnActiveArtboard;
-    if (artboardId && elementId) {
-      const activeAb = artboards.find(ab => ab.id === artboardId);
-      if (activeAb) {
-        const elementToCopy = activeAb.elements.find(el => el.id === elementId);
+    if (!artboardId) return;
+    const activeAb = artboards.find(ab => ab.id === artboardId);
+    if (!activeAb) return;
 
-        if (elementToCopy) {
-          copyToClipboard(elementToCopy);
-          toast({ title: "Copied", description: `${elementToCopy.type} element copied to clipboard.` });
-        }
-      }
+    let elementsToCopy: ArtboardElement[] = [];
+    if (targetElementId) {
+      const selectionOnTarget = artboardId === activeArtboardId ? selectedElementIdsOnActiveArtboard : [];
+      const wanted = selectionOnTarget.includes(targetElementId) ? new Set(selectionOnTarget) : new Set([targetElementId]);
+      elementsToCopy = activeAb.elements.filter(el => wanted.has(el.id));
+    } else if (artboardId === activeArtboardId) {
+      const wanted = new Set(selectedElementIdsOnActiveArtboard);
+      elementsToCopy = activeAb.elements.filter(el => wanted.has(el.id));
+    }
+
+    if (elementsToCopy.length > 0) {
+      copyElementsToClipboard(elementsToCopy);
+      toast({
+        title: "Copied",
+        description: elementsToCopy.length === 1
+          ? `${elementsToCopy[0].type} element copied to clipboard.`
+          : `${elementsToCopy.length} elements copied to clipboard.`,
+      });
     }
   };
 
   // Define the paste element handler. The context menu passes the right-clicked
-  // artboard and a paste point (artboard coordinates) so the element lands
+  // artboard and a paste point (artboard coordinates) so the set lands centered
   // under the cursor; the keyboard shortcut offsets from the original instead.
+  // A multi-element paste preserves the relative arrangement.
   const handlePasteElement = (targetArtboardId?: string | null, pastePoint?: Point | null) => {
     const artboardId = targetArtboardId ?? activeArtboardId;
-    if (artboardId && clipboardItem) {
+    if (artboardId && clipboardItems.length > 0) {
       const targetArtboard = artboards.find(ab => ab.id === artboardId);
-      const elementWidth = clipboardItem.size?.width ?? 0;
-      const elementHeight = clipboardItem.size?.height ?? 0;
-      const position = pastePoint && targetArtboard
-        ? {
-            x: Math.max(0, Math.min(pastePoint.x - elementWidth / 2, targetArtboard.size.width - elementWidth)),
-            y: Math.max(0, Math.min(pastePoint.y - elementHeight / 2, targetArtboard.size.height - elementHeight)),
-          }
-        : {
-            x: clipboardItem.position.x + 20, // Offset position slightly
-            y: clipboardItem.position.y + 20
-          };
-      const newElement = {
-        ...JSON.parse(JSON.stringify(clipboardItem)),
-        id: `el_${Date.now()}_${Math.random().toString(36).substr(2, 5)}`, // New unique ID
-        position
-      };
+      const bounds = selectionBounds(clipboardItems);
+      const stamp = Date.now();
+
+      let offsetX = 20; // Offset position slightly when no paste point is given
+      let offsetY = 20;
+      if (pastePoint && targetArtboard && bounds) {
+        offsetX = pastePoint.x - bounds.width / 2 - bounds.left;
+        offsetY = pastePoint.y - bounds.height / 2 - bounds.top;
+        // Clamp so the pasted set stays inside the artboard
+        offsetX = Math.max(-bounds.left, Math.min(offsetX, targetArtboard.size.width - bounds.right));
+        offsetY = Math.max(-bounds.top, Math.min(offsetY, targetArtboard.size.height - bounds.bottom));
+      }
+
+      const newElements = clipboardItems.map((item, index) => ({
+        ...JSON.parse(JSON.stringify(item)),
+        id: `el_${stamp}_${index}_${Math.random().toString(36).substr(2, 5)}`, // New unique IDs
+        position: { x: item.position.x + offsetX, y: item.position.y + offsetY },
+      })) as ArtboardElement[];
 
       const updatedArtboards = artboards.map(ab => {
         if (ab.id === artboardId) {
           return {
             ...ab,
-            elements: [...ab.elements, newElement]
+            elements: [...ab.elements, ...newElements]
           };
         }
         return ab;
@@ -2109,8 +2205,13 @@ export function OpenScreenshotGeneratorLayout() {
       if (artboardId !== activeArtboardId) {
         setActiveArtboardId(artboardId);
       }
-      setSelectedElementIdOnActiveArtboard(newElement.id);
-      toast({ title: "Pasted", description: `${newElement.type} element pasted to artboard.` });
+      setSelectedElementIdsOnActiveArtboard(newElements.map(el => el.id));
+      toast({
+        title: "Pasted",
+        description: newElements.length === 1
+          ? `${newElements[0].type} element pasted to artboard.`
+          : `${newElements.length} elements pasted to artboard.`,
+      });
     } else if (!artboardId) {
       toast({
         title: "Cannot Paste",
@@ -2164,86 +2265,28 @@ export function OpenScreenshotGeneratorLayout() {
 
       if (artboardId) {
         setActiveArtboardId(artboardId);
-        setSelectedElementIdOnActiveArtboard(elementId);
+        if (elementId) {
+          // Right-clicking an element that is already in the selection keeps
+          // the set (so Copy acts on all of it); otherwise it selects alone.
+          setSelectedElementIdsOnActiveArtboard(
+            artboardId === activeArtboardId && selectedElementIdsOnActiveArtboard.includes(elementId)
+              ? selectedElementIdsOnActiveArtboard
+              : [elementId]
+          );
+        } else {
+          setSelectedElementIdsOnActiveArtboard([]);
+        }
       }
       setContextMenu({ x: e.clientX, y: e.clientY, elementId, artboardId, pastePoint });
     };
 
     document.addEventListener('contextmenu', handleContextMenu);
     return () => document.removeEventListener('contextmenu', handleContextMenu);
-  }, [isPreviewOpen]);
+  }, [isPreviewOpen, activeArtboardId, selectedElementIdsOnActiveArtboard]);
   
-  // Add keyboard shortcuts for copy and paste
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      // Preview mode has its own keyboard handling
-      if (isPreviewOpen) return;
-      // Skip if we're typing in an input, textarea, etc.
-      if (
-        e.target instanceof HTMLInputElement || 
-        e.target instanceof HTMLTextAreaElement ||
-        (e.target instanceof HTMLElement && e.target.isContentEditable)
-      ) {
-        return;
-      }
-
-      // Copy: Ctrl+C or Cmd+C
-      if ((e.ctrlKey || e.metaKey) && e.key === 'c') {
-        e.preventDefault();
-        if (activeArtboardId && selectedElementIdOnActiveArtboard) {
-          handleCopyElement();
-        }
-      }
-
-      // Paste: Ctrl+V or Cmd+V
-      if ((e.ctrlKey || e.metaKey) && e.key === 'v') {
-        e.preventDefault();
-        if (clipboardItem) {
-          handlePasteElement();
-        }
-      }
-
-      // Delete key for element or artboard deletion
-      if (e.key === 'Delete' || e.key === 'Backspace') {
-        e.preventDefault(); // Prevent browser navigation
-        handleDeleteSelected();
-      }
-
-      // Undo: Ctrl+Z or Cmd+Z
-      if ((e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey) {
-        e.preventDefault();
-        if (historyIndex > 0) {
-          handleUndo();
-        }
-      }
-
-      // Redo: Ctrl+Shift+Z or Cmd+Shift+Z or Ctrl+Y or Cmd+Y
-      if (((e.ctrlKey || e.metaKey) && e.key === 'z' && e.shiftKey) || 
-          ((e.ctrlKey || e.metaKey) && e.key === 'y')) {
-        e.preventDefault();
-        if (historyIndex < history.length - 1) {
-          handleRedo();
-        }
-      }
-
-      // Tool shortcuts: H for hand/pan tool, V for selection tool
-      if (e.key === 'h' || e.key === 'H') {
-        e.preventDefault();
-        setActiveTool('pan');
-      }
-
-      if (e.key === 'v' || e.key === 'V') {
-        e.preventDefault();
-        setActiveTool('select');
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [handleDeleteSelected, handleUndo, handleRedo, historyIndex, history.length, activeArtboardId, selectedElementIdOnActiveArtboard, clipboardItem, isPreviewOpen]);
+  // NOTE: keyboard shortcuts live in a single consolidated keydown effect
+  // further up (delete/undo/redo/clipboard/select-all/nudge). A second,
+  // identical keydown effect used to be registered here; do not re-add one.
 
   // Common function to load project data and apply positioning
   const loadProjectFromData = async (projectData: ArtboardState[], projectName: string, projectId: string) => {
@@ -2266,7 +2309,7 @@ export function OpenScreenshotGeneratorLayout() {
       
       // Automatically select the first artboard
       setActiveArtboardId(finalArtboards.length > 0 ? finalArtboards[0].id : null);
-      setSelectedElementIdOnActiveArtboard(null);
+      setSelectedElementIdsOnActiveArtboard([]);
       setIsTemplateSelectorOpen(false);
 
       // Update recent projects list
@@ -2875,7 +2918,9 @@ const generateRandomProjectName = (): string => {
       handleArtboardsUpdate(
         artboards.map((ab) => (ab.id === boardId ? { ...ab, elements: ab.elements.filter((el) => el.id !== elementId) } : ab))
       );
-      if (selectedElementIdOnActiveArtboard === elementId) setSelectedElementIdOnActiveArtboard(null);
+      if (selectedElementIdsOnActiveArtboard.includes(elementId)) {
+        setSelectedElementIdsOnActiveArtboard((prev) => prev.filter((id) => id !== elementId));
+      }
       return true;
     },
     reorderElement: ({ artboardId, elementId, action, index }) => {
@@ -3247,7 +3292,7 @@ const generateRandomProjectName = (): string => {
             onUndo={handleUndo}
             onRedo={handleRedo}
             onDeleteSelected={handleDeleteSelected}
-            isElementSelected={!!selectedElementIdOnActiveArtboard}
+            isElementSelected={selectedElementIdsOnActiveArtboard.length > 0}
             isArtboardSelected={!!activeArtboardId}
             activeTool={activeTool}
             onSetActiveTool={setActiveTool}
@@ -3276,9 +3321,11 @@ const generateRandomProjectName = (): string => {
                 onAddElementToArtboard={handleAddElementToArtboard}
                 activeArtboardId={activeArtboardId}
                 setActiveArtboardId={handleArtboardSelection}
-                selectedElementIdOnActiveArtboard={selectedElementIdOnActiveArtboard}
+                selectedElementIdsOnActiveArtboard={selectedElementIdsOnActiveArtboard}
                 setSelectedElementIdOnActiveArtboard={handleElementSelectionOnArtboard}
+                setSelectedElementIdsOnActiveArtboard={handleElementsSelectionOnArtboard}
                 canvasZoom={canvasZoom}
+                onCanvasZoomChange={setCanvasZoom}
                 artboardRefs={artboardRefs}
                 onAddNewArtboardFromToolbar={handleAddNewArtboardAfter}
                 onDuplicateArtboardFromToolbar={handleDuplicateArtboard}
@@ -3327,7 +3374,7 @@ const generateRandomProjectName = (): string => {
                   x={contextMenu.x}
                   y={contextMenu.y}
                   canCopy={!!contextMenu.elementId && !!contextMenu.artboardId}
-                  canPaste={!!clipboardItem && !!(contextMenu.artboardId || activeArtboardId)}
+                  canPaste={clipboardItems.length > 0 && !!(contextMenu.artboardId || activeArtboardId)}
                   onCopy={() => handleCopyElement(contextMenu.artboardId, contextMenu.elementId)}
                   onPaste={() => handlePasteElement(contextMenu.artboardId, contextMenu.pastePoint)}
                   onClose={() => setContextMenu(null)}
@@ -3357,11 +3404,13 @@ const generateRandomProjectName = (): string => {
                   <div className="min-h-[10rem] flex-1 overflow-hidden">
                     <PropertiesPanel
                       selectedElement={selectedElementDetails}
+                      selectionCount={selectedElementIdsOnActiveArtboard.length}
+                      onAlignElements={handleAlignElements}
                       onUpdateElement={handleUpdateSelectedElement}
                       onUpdateElementById={handleUpdateElementById}
                       onTranslateElement={handleTranslateTextElement}
                       activeArtboardDetails={
-                        activeArtboardId && !selectedElementIdOnActiveArtboard ? activeArtboard : null
+                        activeArtboardId && selectedElementIdsOnActiveArtboard.length === 0 ? activeArtboard : null
                       }
                       onUpdateArtboardDetails={handleUpdateArtboardDetails}
                       className="h-full border-l-0 shadow-none"
@@ -3413,7 +3462,7 @@ const generateRandomProjectName = (): string => {
                   >
                     <LayersPanel
                       elements={activeArtboardElements}
-                      selectedElementId={selectedElementIdOnActiveArtboard}
+                      selectedElementIds={selectedElementIdsOnActiveArtboard}
                       onSelectElement={handleSelectElementFromLayerPanel}
                       onMoveElementLayer={handleMoveElementLayer}
                       onDeleteElement={handleDeleteElementFromLayerPanel}

--- a/src/components/open-screenshot-generator/OpenScreenshotGeneratorLayout.tsx
+++ b/src/components/open-screenshot-generator/OpenScreenshotGeneratorLayout.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useState, useEffect, useLayoutEffect, useCallback, useMemo, useRef, useDeferredValue } from 'react';
-import { toPng } from 'html-to-image';
+import { toPng, toJpeg, toSvg } from 'html-to-image';
 import { preloadGoogleFonts } from '@/services/fontService';
 import { isTauri, sanitizeFileName, saveBlobToDisk, saveBlobToPath, saveDataUrlToDisk, saveDataUrlToPath, pickExportDirectory, openExternal } from '@/lib/desktop';
 import { analyzeArtboardForVideo, exportArtboardVideo, projectHasVideoContent, type ArtboardVideoInfo } from '@/lib/video/videoExport';
@@ -26,7 +26,7 @@ import { TranslateDialog, getLanguageName } from './TranslateDialog';
 import { translateText, detectLanguage, isTranslationEnabled, AUTO_DETECT } from '@/services/translation';
 import { Logo } from './Logo';
 import type { ArtboardState, ElementType, Point, ShapeType, DeviceType, ArtboardElement, TextElementProps, ShapeElementProps, DeviceFrameElementProps, ImageElementProps, Project, Size } from '@/types/artboard';
-import { ExportDialog, type ExportSelection, type VideoExportRequest, type VideoExportProgress } from './ExportDialog';
+import { ExportDialog, type ExportSelection, type ExportImageFormat, type VideoExportRequest, type VideoExportProgress } from './ExportDialog';
 import { AppPreviewExportDialog } from './AppPreviewExportDialog';
 import { ALL_CANVAS_SIZE_PRESETS } from '@/lib/sizePresets';
 import { artboardBackground } from '@/lib/artboardBackground';
@@ -125,6 +125,40 @@ function calculateArtboardPositions(artboards: ArtboardState[]): ArtboardState[]
     currentX += (ab.size.width * DISPLAY_SCALE_FACTOR) + ARTBOARD_MARGIN;
 
     return { ...ab, position: newPosition };
+  });
+}
+
+// html-to-image has no WebP encoder, so WebP exports capture PNG first and
+// re-encode through a hidden canvas. The canvas is pre-filled with the
+// artboard colour because WebP export is flattened (no alpha), matching JPEG.
+async function rasterToWebPDataUrl(
+  pngDataUrl: string,
+  backgroundColor: string,
+  quality: number
+): Promise<string> {
+  const image = await new Promise<HTMLImageElement>((resolve, reject) => {
+    const img = new window.Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error('Could not decode the captured PNG for WebP encoding.'));
+    img.src = pngDataUrl;
+  });
+  const canvas = document.createElement('canvas');
+  canvas.width = image.naturalWidth;
+  canvas.height = image.naturalHeight;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Could not create a canvas for WebP encoding.');
+  ctx.fillStyle = backgroundColor;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.drawImage(image, 0, 0);
+  const blob = await new Promise<Blob | null>((resolve) =>
+    canvas.toBlob(resolve, 'image/webp', quality)
+  );
+  if (!blob) throw new Error('WebP encoding failed.');
+  return new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(new Error('Could not read the encoded WebP.'));
+    reader.readAsDataURL(blob);
   });
 }
 
@@ -1248,7 +1282,7 @@ export function OpenScreenshotGeneratorLayout() {
     }
   };
 
-  // Capture a list of artboards to PNG downloads by grabbing each board's
+  // Capture a list of artboards to image downloads by grabbing each board's
   // live DOM node (matched by artboard id). The list must be what the canvas
   // is currently rendering — for generated formats, handleConfirmExport
   // swaps the converted list in first and restores afterwards.
@@ -1256,13 +1290,15 @@ export function OpenScreenshotGeneratorLayout() {
     list: ArtboardState[],
     exportDir?: string | null,
     options: {
+      format?: ExportImageFormat;
+      quality?: number;
       // Restrict the capture to these artboard ids; omitted captures the whole
       // list. Skipped boards still consume their loop index, so filename
       // order prefixes match the on-canvas positions.
       selectedIds?: ReadonlySet<string>;
     } = {},
   ) => {
-    const { selectedIds } = options;
+    const { format = 'png', quality = 0.92, selectedIds } = options;
     // Array order matches canvas order (calculateArtboardPositions lays boards
     // out left-to-right by index), so the loop index is the on-canvas position.
     const orderPadWidth = Math.max(2, String(list.length).length);
@@ -1294,7 +1330,7 @@ export function OpenScreenshotGeneratorLayout() {
 
         // Use html-to-image to capture the artboard at exact specified dimensions
         const { backgroundColor, backgroundImage } = artboardBackground(artboard);
-        const imageDataUrl = await toPng(artboardElement, {
+        const captureOptions = {
           width: artboard.size.width,
           height: artboard.size.height,
           backgroundColor,
@@ -1302,7 +1338,7 @@ export function OpenScreenshotGeneratorLayout() {
           cacheBust: true, // Prevent caching issues
           // Editor chrome (selection outlines, resize handles, upload buttons)
           // must never be baked into the exported image
-          filter: (node) => {
+          filter: (node: Node) => {
             const el = node as HTMLElement;
             return !(el?.hasAttribute?.('data-export-exclude') || el?.hasAttribute?.('data-interaction-handle'));
           },
@@ -1311,7 +1347,20 @@ export function OpenScreenshotGeneratorLayout() {
             height: `${artboard.size.height}px`,
             backgroundImage,
           }
-        });
+        };
+
+        let imageDataUrl: string;
+        if (format === 'jpeg') {
+          // JPEG has no alpha: html-to-image fills transparent pixels with backgroundColor
+          imageDataUrl = await toJpeg(artboardElement, { ...captureOptions, quality });
+        } else if (format === 'svg') {
+          imageDataUrl = await toSvg(artboardElement, captureOptions);
+        } else if (format === 'webp') {
+          const pngDataUrl = await toPng(artboardElement, captureOptions);
+          imageDataUrl = await rasterToWebPDataUrl(pngDataUrl, backgroundColor, quality);
+        } else {
+          imageDataUrl = await toPng(artboardElement, captureOptions);
+        }
 
         // Restore original styling after export
         artboardElement.style.transform = originalTransform;
@@ -1328,7 +1377,8 @@ export function OpenScreenshotGeneratorLayout() {
           ? DEVICE_FORMAT_PRESETS.find((p) => p.id === artboardFormat)?.label
           : undefined;
         const deviceSuffix = deviceLabel ? `_${deviceLabel.replace(/\s+/g, '_')}` : '';
-        const filename = `${orderPrefix}_${artboard.name.replace(/\s+/g, '_')}${deviceSuffix}.png`;
+        const extension = format === 'jpeg' ? 'jpg' : format;
+        const filename = `${orderPrefix}_${artboard.name.replace(/\s+/g, '_')}${deviceSuffix}.${extension}`;
         // Desktop-safe save: batch exports write into the pre-picked folder,
         // single files get a native save dialog in Tauri or an anchor
         // download on the web
@@ -1370,7 +1420,7 @@ export function OpenScreenshotGeneratorLayout() {
   // engine as the Devices menu, rendered, captured, then the original state
   // is restored — plain setArtboards keeps history and the saved project
   // untouched, so this can never corrupt the user's work.
-  const handleConfirmExport = async ({ asIs, generateFormats, artboardIds }: ExportSelection) => {
+  const handleConfirmExport = async ({ asIs, generateFormats, artboardIds, format, quality }: ExportSelection) => {
     setIsExportDialogOpen(false);
 
     const original = artboards;
@@ -1409,7 +1459,7 @@ export function OpenScreenshotGeneratorLayout() {
       window.dispatchEvent(new CustomEvent('artboard:export', { detail: { phase: 'begin' } }));
       await new Promise((resolve) => setTimeout(resolve, 100));
       try {
-        await captureArtboards(list, exportDir, { selectedIds });
+        await captureArtboards(list, exportDir, { format, quality, selectedIds });
       } finally {
         window.dispatchEvent(new CustomEvent('artboard:export', { detail: { phase: 'end' } }));
       }
@@ -2631,6 +2681,10 @@ const generateRandomProjectName = (): string => {
   // does not have to ship a full-size PNG as base64, and writing straight to
   // disk through Rust — the JS fs plugin only unlocks paths the user picked in
   // a dialog, and these exports are unattended.
+  //
+  // Deliberately PNG-only: the agent contract promises lossless stills and the
+  // Rust writer (abs_mcp_write_png) stores PNG bytes, so the Export dialog's
+  // format picker (JPEG/SVG/WebP) does not apply here.
   const captureArtboardForMcp = async (
     board: ArtboardState,
     options: { scale?: number; save?: boolean; directory?: string; fileName?: string; includeImage?: boolean }

--- a/src/components/open-screenshot-generator/PropertiesPanel.tsx
+++ b/src/components/open-screenshot-generator/PropertiesPanel.tsx
@@ -9,9 +9,10 @@ import { Slider } from '@/components/ui/slider';
 import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover';
-import { UploadCloudIcon, PaintbrushIcon, Palette, Plus, Minus, Bold, Italic, Underline, Strikethrough, AlignLeft, AlignCenter, AlignRight, ClapperboardIcon, Trash2Icon, Languages } from 'lucide-react';
+import { UploadCloudIcon, PaintbrushIcon, Palette, Plus, Minus, Bold, Italic, Underline, Strikethrough, AlignLeft, AlignCenter, AlignRight, ClapperboardIcon, Trash2Icon, Languages, AlignStartVertical, AlignCenterVertical, AlignEndVertical, AlignStartHorizontal, AlignCenterHorizontal, AlignEndHorizontal, AlignHorizontalDistributeCenter, AlignVerticalDistributeCenter } from 'lucide-react';
 import { saveMedia } from '@/lib/mediaStore';
 import { DEFAULT_GRADIENT, normalizeGradient } from '@/lib/artboardBackground';
+import type { ElementAlignment } from '@/lib/elementAlignment';
 import { VIDEO_ACCEPT } from './elements/VideoElement';
 import { useToast } from '@/hooks/use-toast';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -40,6 +41,12 @@ const ELEMENT_PANEL_TITLES: Partial<Record<ArtboardElement['type'], string>> = {
 
 interface PropertiesPanelProps {
   selectedElement: ArtboardElement | null;
+  // Total number of selected elements on the active artboard. Values above 1
+  // switch the panel to its multi-select state (count + alignment controls).
+  selectionCount?: number;
+  // Alignment/distribute actions. Single selection aligns inside the
+  // artboard; multi-selection aligns inside the selection's bounding box.
+  onAlignElements?: (mode: ElementAlignment) => void;
   onUpdateElement: (updates: Partial<ArtboardElement>) => void;
   /**
    * Update an element by id even when it is no longer selected. Used to
@@ -165,6 +172,8 @@ const gradientPresets = [
 
 export function PropertiesPanel({
   selectedElement, 
+  selectionCount,
+  onAlignElements,
   onUpdateElement, 
   onUpdateElementById,
   onTranslateElement,
@@ -2163,6 +2172,89 @@ export function PropertiesPanel({
     );
   };
 
+  // Alignment section, shown for both single selections (aligned to the
+  // artboard) and multi-selections (aligned to the selection bounding box,
+  // with distribute once 3+ elements are selected).
+  const renderAlignmentControls = () => {
+    if (!onAlignElements) return null;
+    const count = selectionCount ?? (selectedElement ? 1 : 0);
+    if (count === 0) return null;
+
+    const alignButtons: Array<{ mode: ElementAlignment; title: string; icon: React.ReactNode }> = [
+      { mode: 'left', title: 'Align left', icon: <AlignStartVertical className="h-4 w-4" /> },
+      { mode: 'center-h', title: 'Align center horizontally', icon: <AlignCenterVertical className="h-4 w-4" /> },
+      { mode: 'right', title: 'Align right', icon: <AlignEndVertical className="h-4 w-4" /> },
+      { mode: 'top', title: 'Align top', icon: <AlignStartHorizontal className="h-4 w-4" /> },
+      { mode: 'middle-v', title: 'Align middle vertically', icon: <AlignCenterHorizontal className="h-4 w-4" /> },
+      { mode: 'bottom', title: 'Align bottom', icon: <AlignEndHorizontal className="h-4 w-4" /> },
+    ];
+
+    return (
+      <div className="space-y-2">
+        <Label className="text-xs font-medium">
+          {count > 1 ? 'Align selection' : 'Align to artboard'}
+        </Label>
+        <div className="grid grid-cols-6 gap-1">
+          {alignButtons.map(({ mode, title, icon }) => (
+            <Button
+              key={mode}
+              variant="outline"
+              size="icon"
+              className="h-8 w-8"
+              title={title}
+              aria-label={title}
+              onClick={() => onAlignElements(mode)}
+            >
+              {icon}
+            </Button>
+          ))}
+        </div>
+        {count >= 3 && (
+          <div className="grid grid-cols-2 gap-1">
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-8 gap-1.5"
+              title="Distribute horizontally"
+              onClick={() => onAlignElements('distribute-h')}
+            >
+              <AlignHorizontalDistributeCenter className="h-4 w-4 shrink-0" />
+              <span className="text-xs">Distribute H</span>
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-8 gap-1.5"
+              title="Distribute vertically"
+              onClick={() => onAlignElements('distribute-v')}
+            >
+              <AlignVerticalDistributeCenter className="h-4 w-4 shrink-0" />
+              <span className="text-xs">Distribute V</span>
+            </Button>
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  // Multi-selection: count plus alignment controls. Per-property editing is
+  // single-selection only.
+  if (selectionCount !== undefined && selectionCount > 1) {
+    return (
+      <div className={cn("w-full h-full bg-card border-l shadow-md flex flex-col overflow-hidden", className)} suppressHydrationWarning>
+        <div className="px-4 py-3 border-b bg-card">
+          <div className="font-medium text-foreground">{selectionCount} elements selected</div>
+        </div>
+        <div className="flex-1 overflow-y-auto px-4 py-3 space-y-4 text-sm">
+          {renderAlignmentControls()}
+          <p className="text-xs text-muted-foreground">
+            Select a single element to edit its properties
+          </p>
+        </div>
+      </div>
+    );
+  }
+
   // No element or artboard selected
   if (!selectedElement && !activeArtboardDetails) {
     return (
@@ -2360,6 +2452,7 @@ export function PropertiesPanel({
           </div>
         </div>
         <div className="flex-1 overflow-y-auto px-4 py-3 space-y-4 text-sm">
+          {renderAlignmentControls()}
           {selectedElement.type === 'text' && renderTextProperties(selectedElement as TextElementProps)}
           {selectedElement.type === 'shape' && renderShapeProperties(selectedElement as ShapeElementProps)}
           {selectedElement.type === 'device' && renderDeviceProperties(selectedElement as DeviceFrameElementProps)}

--- a/src/components/open-screenshot-generator/UploadsPanel.tsx
+++ b/src/components/open-screenshot-generator/UploadsPanel.tsx
@@ -1,0 +1,338 @@
+"use client";
+import type React from 'react';
+import { useCallback, useRef, useState } from 'react';
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  ImageIcon,
+  ImagePlusIcon,
+  Loader2Icon,
+  PencilIcon,
+  Trash2Icon,
+} from "lucide-react";
+import type { ElementType, ShapeType, DeviceType } from '@/types/artboard';
+import {
+  deleteMedia,
+  getMediaDataUrl,
+  renameMedia,
+  saveMedia,
+  useMediaUrl,
+  type MediaAsset,
+} from '@/lib/mediaStore';
+import { useToast } from '@/hooks/use-toast';
+import { cn } from '@/lib/utils';
+
+// Same signature as ElementPalette's PaletteDragStart, redeclared so this
+// panel does not import from its parent (LibraryItemTile does the same).
+type PaletteDragStart = (
+  e: React.DragEvent<HTMLElement> | null,
+  type: ElementType,
+  subType?: ShapeType | DeviceType,
+  styleProps?: Record<string, any>
+) => void;
+
+/** The element payload a dropped/clicked upload mints, same shape the Images library tiles use. */
+const stylePropsFor = (asset: MediaAsset, dataUrl: string) => ({
+  imageSrc: dataUrl,
+  imageAlt: asset.name,
+  name: asset.name,
+  defaultSize: { width: asset.width || 400, height: asset.height || 300 },
+});
+
+const RenameInput: React.FC<{
+  initial: string;
+  onCommit: (name: string) => void;
+  onCancel: () => void;
+}> = ({ initial, onCommit, onCancel }) => {
+  const [value, setValue] = useState(initial);
+  return (
+    <Input
+      autoFocus
+      value={value}
+      aria-label="Rename upload"
+      onChange={(e) => setValue(e.target.value)}
+      onFocus={(e) => e.currentTarget.select()}
+      onBlur={() => onCommit(value)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          onCommit(value);
+        } else if (e.key === 'Escape') {
+          e.preventDefault();
+          onCancel();
+        }
+      }}
+      className="h-6 px-1 text-[10px]"
+    />
+  );
+};
+
+/** One uploaded image: draggable thumbnail + rename/delete affordances on hover. */
+const UploadedImageTile: React.FC<{
+  asset: MediaAsset;
+  renaming: boolean;
+  onDragStart: PaletteDragStart;
+  onEnsureDataUrl: (id: string) => Promise<string | null>;
+  onPeekDataUrl: (id: string) => string | undefined;
+  onBeginRename: () => void;
+  onCommitRename: (name: string) => void;
+  onCancelRename: () => void;
+  onDelete: () => void;
+}> = ({
+  asset,
+  renaming,
+  onDragStart,
+  onEnsureDataUrl,
+  onPeekDataUrl,
+  onBeginRename,
+  onCommitRename,
+  onCancelRename,
+  onDelete,
+}) => {
+  // Object URL from the shared cache: thumbnails never hold data URLs.
+  const thumbUrl = useMediaUrl(asset.id);
+
+  return (
+    <li className="group relative flex flex-col gap-1">
+      <button
+        type="button"
+        className="flex aspect-square w-full cursor-grab items-center justify-center overflow-hidden rounded-lg bg-accent/10 p-1.5 transition-colors hover:bg-accent/25 active:cursor-grabbing"
+        draggable
+        onDragStart={(e) => {
+          const dataUrl = onPeekDataUrl(asset.id);
+          if (!dataUrl) {
+            // The pointerdown/hover prime almost always wins this race; if it
+            // did not, cancel the drag, keep priming, and let the retry work.
+            e.preventDefault();
+            void onEnsureDataUrl(asset.id);
+            return;
+          }
+          onDragStart(e, 'image', undefined, stylePropsFor(asset, dataUrl));
+        }}
+        onClick={() => {
+          void onEnsureDataUrl(asset.id).then((dataUrl) => {
+            if (dataUrl) (onDragStart as any)(null, 'image', undefined, stylePropsFor(asset, dataUrl));
+          });
+        }}
+        onPointerDown={() => void onEnsureDataUrl(asset.id)}
+        onPointerEnter={() => void onEnsureDataUrl(asset.id)}
+        title={`Add ${asset.name}`}
+        aria-label={`Add ${asset.name}`}
+      >
+        {thumbUrl ? (
+          <img src={thumbUrl} alt="" className="max-w-full max-h-full object-contain pointer-events-none" draggable={false} />
+        ) : (
+          <ImageIcon className="w-5 h-5 text-muted-foreground/50" />
+        )}
+      </button>
+      {renaming ? (
+        <RenameInput initial={asset.name} onCommit={onCommitRename} onCancel={onCancelRename} />
+      ) : (
+        <span className="text-[10px] text-muted-foreground group-hover:text-foreground transition-colors text-center leading-tight break-words">
+          {asset.name}
+        </span>
+      )}
+      {!renaming && (
+        <div className="absolute right-1 top-1 flex gap-0.5 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
+          <button
+            type="button"
+            onClick={onBeginRename}
+            title={`Rename ${asset.name}`}
+            aria-label={`Rename ${asset.name}`}
+            className="flex h-5 w-5 items-center justify-center rounded-full border bg-background text-muted-foreground shadow transition-colors hover:text-foreground"
+          >
+            <PencilIcon className="h-3 w-3" />
+          </button>
+          <button
+            type="button"
+            onClick={onDelete}
+            title={`Delete ${asset.name}`}
+            aria-label={`Delete ${asset.name}`}
+            className="flex h-5 w-5 items-center justify-center rounded-full border bg-background text-muted-foreground shadow transition-colors hover:text-destructive"
+          >
+            <Trash2Icon className="h-3 w-3" />
+          </button>
+        </div>
+      )}
+    </li>
+  );
+};
+
+interface UploadsPanelProps {
+  // The palette owns the list (its Images overview card shows recent uploads);
+  // this panel mutates and then asks the palette to re-list via onChanged.
+  assets: MediaAsset[];
+  onChanged: () => void;
+  onDragStart: PaletteDragStart;
+}
+
+/**
+ * The user's uploaded image library (Images tab > Your uploads). Files are
+ * stored as blobs in the Dexie media table; dragging a tile onto the canvas
+ * mints the element's imageSrc as a data URL read from the blob, so the
+ * project row serializes exactly like an Images-library drop.
+ */
+export function UploadsPanel({ assets, onChanged, onDragStart }: UploadsPanelProps) {
+  const { toast } = useToast();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [dragActive, setDragActive] = useState(false);
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+
+  // Data URLs are minted only for tiles the user actually interacts with
+  // (hover/press prime, dragstart consumes synchronously, click awaits), so a
+  // large library never sits in memory as one base64 string per tile.
+  const dataUrlCacheRef = useRef(new Map<string, string>());
+  const dataUrlInflightRef = useRef(new Map<string, Promise<string | null>>());
+
+  const ensureDataUrl = useCallback((id: string): Promise<string | null> => {
+    const cached = dataUrlCacheRef.current.get(id);
+    if (cached) return Promise.resolve(cached);
+    const inflight = dataUrlInflightRef.current.get(id);
+    if (inflight) return inflight;
+    const promise = getMediaDataUrl(id).then((dataUrl) => {
+      if (dataUrl) dataUrlCacheRef.current.set(id, dataUrl);
+      return dataUrl;
+    });
+    dataUrlInflightRef.current.set(id, promise);
+    const clear = () => dataUrlInflightRef.current.delete(id);
+    promise.then(clear, clear);
+    return promise;
+  }, []);
+
+  const peekDataUrl = useCallback((id: string) => dataUrlCacheRef.current.get(id), []);
+
+  const addFiles = async (files: File[]) => {
+    const images = files.filter((file) => file.type.startsWith('image/'));
+    if (images.length === 0) {
+      if (files.length > 0) setError('Only image files can be uploaded here.');
+      return;
+    }
+    setError(null);
+    setBusy(true);
+    try {
+      // Sequential saves keep createdAt in the order the files were picked.
+      for (const file of images) {
+        await saveMedia(file, file.name);
+      }
+      onChanged();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Those images could not be read.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleRename = async (asset: MediaAsset, name: string) => {
+    setRenamingId(null);
+    const trimmed = name.trim();
+    if (!trimmed || trimmed === asset.name) return;
+    try {
+      await renameMedia(asset.id, trimmed);
+      onChanged();
+    } catch {
+      toast({ title: 'Rename failed', description: 'The upload could not be renamed.', variant: 'destructive' });
+    }
+  };
+
+  const handleDelete = async (asset: MediaAsset) => {
+    try {
+      // Elements created from this upload hold their own data URL copy, so
+      // deleting the library row never blanks a canvas element.
+      await deleteMedia(asset.id);
+      dataUrlCacheRef.current.delete(asset.id);
+      onChanged();
+    } catch {
+      toast({ title: 'Delete failed', description: 'The upload could not be deleted.', variant: 'destructive' });
+    }
+  };
+
+  return (
+    <div
+      onDragOver={(e) => {
+        if (busy || !e.dataTransfer.types.includes('Files')) return;
+        e.preventDefault();
+        setDragActive(true);
+      }}
+      onDragLeave={() => setDragActive(false)}
+      onDrop={(e) => {
+        if (e.dataTransfer.files.length === 0) return;
+        e.preventDefault();
+        setDragActive(false);
+        if (!busy) void addFiles(Array.from(e.dataTransfer.files));
+      }}
+      className={cn(
+        'rounded-lg transition-colors',
+        dragActive && 'bg-primary/5 ring-2 ring-inset ring-primary'
+      )}
+    >
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        multiple
+        className="hidden"
+        onChange={(e) => {
+          if (e.target.files) void addFiles(Array.from(e.target.files));
+          e.target.value = '';
+        }}
+      />
+
+      {assets.length === 0 ? (
+        <div className="flex flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed border-muted-foreground/25 px-4 py-6 text-center">
+          {busy ? (
+            <Loader2Icon className="h-6 w-6 animate-spin text-muted-foreground" />
+          ) : (
+            <ImagePlusIcon className="h-6 w-6 text-muted-foreground" />
+          )}
+          <p className="text-sm text-muted-foreground">No uploads yet. Drop image files here, or</p>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={busy}
+            onClick={() => inputRef.current?.click()}
+          >
+            Choose files
+          </Button>
+          <p className="text-xs text-muted-foreground">PNG, JPEG, WebP, GIF or SVG</p>
+        </div>
+      ) : (
+        <>
+          <div className="mb-2 flex items-center justify-between gap-2 px-1">
+            <p className="text-[11px] text-muted-foreground">Drag a tile onto the canvas, or click to add it</p>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-7 shrink-0 px-2 text-xs"
+              disabled={busy}
+              onClick={() => inputRef.current?.click()}
+            >
+              {busy ? <Loader2Icon className="h-3.5 w-3.5 animate-spin" /> : 'Add'}
+            </Button>
+          </div>
+          <ul className="grid grid-cols-3 gap-2 pr-1">
+            {assets.map((asset) => (
+              <UploadedImageTile
+                key={asset.id}
+                asset={asset}
+                renaming={renamingId === asset.id}
+                onDragStart={onDragStart}
+                onEnsureDataUrl={ensureDataUrl}
+                onPeekDataUrl={peekDataUrl}
+                onBeginRename={() => setRenamingId(asset.id)}
+                onCommitRename={(name) => void handleRename(asset, name)}
+                onCancelRename={() => setRenamingId(null)}
+                onDelete={() => void handleDelete(asset)}
+              />
+            ))}
+          </ul>
+        </>
+      )}
+
+      {error && <p className="mt-2 px-1 text-xs text-destructive">{error}</p>}
+    </div>
+  );
+}

--- a/src/components/open-screenshot-generator/elements/DraggableElement.tsx
+++ b/src/components/open-screenshot-generator/elements/DraggableElement.tsx
@@ -9,10 +9,22 @@ import type { ArtboardElement, Point, Size } from '@/types/artboard';
 interface DraggableElementProps {
   element: ArtboardElement;
   isSelected: boolean;
-  onSelect: (elementId: string, e: React.MouseEvent) => void;
+  // modifiers.additive (Shift/Ctrl/Cmd click) toggles the element in/out of
+  // the current selection; a plain click selects it alone.
+  onSelect: (elementId: string, modifiers?: { additive?: boolean }) => void;
   onUpdateElement: (element: ArtboardElement) => void;
   onDeleteElement: (elementId: string) => void;
   artboardZoom: number;
+  // Canvas-level zoom, only used to keep the selection handles a constant
+  // on-screen size. Mouse conversion reads the rendered DOM instead.
+  canvasZoom?: number;
+  // Group-drag hooks, provided when this element may be part of a
+  // multi-selection. onGroupDragStart returns true when a multi-selection is
+  // active, in which case the parent translates the whole set and commits
+  // once on onGroupDragEnd.
+  onGroupDragStart?: (elementId: string) => boolean;
+  onGroupDragMove?: (dx: number, dy: number) => void;
+  onGroupDragEnd?: (dx: number, dy: number) => void;
   boundary: { width: number; height: number };
   children: React.ReactNode;
 }
@@ -33,6 +45,10 @@ export function DraggableElement({
   onUpdateElement,
   onDeleteElement,
   artboardZoom,
+  canvasZoom = 1,
+  onGroupDragStart,
+  onGroupDragMove,
+  onGroupDragEnd,
   boundary,
   children
 }: DraggableElementProps) {
@@ -45,14 +61,25 @@ export function DraggableElement({
   const [interactionStart, setInteractionStart] = useState<{
     mouseX: number;
     mouseY: number;
+    clientX: number;
+    clientY: number;
     initialPosition: Point;
     initialSize: Size; 
     initialRotation: number;
     initialScale: number; 
     elementCenter: Point;
     handleType?: HandleType;
+    // Move-mode extras: whether the whole selection is being translated by
+    // the parent, and what a no-movement click means for the selection when
+    // the gesture ends (modifier-click toggles off, plain click on a member
+    // of a multi-selection collapses to it alone).
+    groupDrag?: boolean;
+    clickAction?: 'toggle-off' | 'collapse' | 'none';
   } | null>(null);
   const elementRef = useRef<HTMLDivElement>(null);
+  // Latest move delta during a group drag, so mouseup can hand the parent the
+  // final translation for its single history commit.
+  const groupDragDeltaRef = useRef<Point>({ x: 0, y: 0 });
 
   useEffect(() => {
     setPosition(element.position);
@@ -61,14 +88,23 @@ export function DraggableElement({
     setCurrentScale(element.scale);
   }, [element.id, element.position, element.size, element.rotation, element.scale]);
 
+  // Convert a mouse event to artboard coordinates via the artboard's rendered
+  // size, which already includes the display scale, the canvas zoom and every
+  // ancestor transform. Deriving the factor from the DOM (instead of dividing
+  // by constants) keeps the cursor 1:1 with the dragged element at ANY zoom,
+  // with sub-pixel precision.
   const getMousePositionInArtboardSpace = (e: MouseEvent | React.MouseEvent): Point => {
-    const artboardDiv = elementRef.current?.offsetParent as HTMLElement | null;
+    const artboardDiv = (elementRef.current?.closest('[data-artboard-dom-id]') ??
+      elementRef.current?.offsetParent) as HTMLElement | null;
     if (artboardDiv) {
       const artboardRect = artboardDiv.getBoundingClientRect();
+      const originalWidth = Number(artboardDiv.getAttribute('data-original-width')) || boundary.width;
+      const renderedScale = artboardRect.width > 0 && originalWidth > 0
+        ? artboardRect.width / originalWidth
+        : artboardZoom * DISPLAY_SCALE_FACTOR;
       return {
-        // Divide by DISPLAY_SCALE_FACTOR to account for the scaled artboard
-        x: (e.clientX - artboardRect.left) / (artboardZoom * DISPLAY_SCALE_FACTOR),
-        y: (e.clientY - artboardRect.top) / (artboardZoom * DISPLAY_SCALE_FACTOR),
+        x: (e.clientX - artboardRect.left) / renderedScale,
+        y: (e.clientY - artboardRect.top) / renderedScale,
       };
     }
     return { 
@@ -81,7 +117,8 @@ export function DraggableElement({
   const handleInteractionStart = (
     e: React.MouseEvent,
     mode: 'move' | 'rotate' | 'scale' | 'resize',
-    handleType?: HandleType
+    handleType?: HandleType,
+    options?: { clickAction?: 'toggle-off' | 'collapse' | 'none' }
   ) => {
     // Only the left button drags; right-click opens the context menu instead
     if (e.button !== 0) return;
@@ -102,10 +139,17 @@ export function DraggableElement({
     e.stopPropagation();
     if (!elementRef.current) return;
 
-    if (!isSelected) { 
-      onSelect(element.id, e);
+    // Handles (scale/rotate/resize) on an unselected element select it first;
+    // move gestures manage their own selection before calling this.
+    if (!isSelected && options?.clickAction === undefined) { 
+      onSelect(element.id, { additive: false });
     }
     setInteractionMode(mode);
+
+    // Moving an element that belongs to a multi-selection translates the
+    // whole set; the parent drives the positions from here on.
+    const groupDrag = mode === 'move' ? (onGroupDragStart?.(element.id) ?? false) : false;
+    groupDragDeltaRef.current = { x: 0, y: 0 };
 
     const mousePosArtboard = getMousePositionInArtboardSpace(e);
     
@@ -115,6 +159,8 @@ export function DraggableElement({
     setInteractionStart({
       mouseX: mousePosArtboard.x,
       mouseY: mousePosArtboard.y,
+      clientX: e.clientX,
+      clientY: e.clientY,
       initialPosition: { ...position },
       initialSize: { ...currentSize }, 
       initialRotation: currentRotation,
@@ -124,6 +170,8 @@ export function DraggableElement({
         y: position.y + displayHeight / 2,
       },
       handleType: handleType,
+      groupDrag,
+      clickAction: options?.clickAction,
     });
   };
 
@@ -134,6 +182,9 @@ export function DraggableElement({
 
       const mousePosArtboard = getMousePositionInArtboardSpace(e);
       const { initialPosition, initialSize, initialRotation, initialScale, elementCenter, handleType } = interactionStart;
+      // Ctrl/Cmd held = free precise movement: bypass any snapping or
+      // rounding and keep full sub-pixel precision.
+      const freeMovement = e.ctrlKey || e.metaKey;
       
       const rad = currentRotation * (Math.PI / 180); 
       const cosR = Math.cos(rad);
@@ -149,13 +200,24 @@ export function DraggableElement({
 
 
       if (interactionMode === 'move') {
+        if (interactionStart.groupDrag) {
+          // The parent translates every selected element by the same delta
+          // and commits once on mouseup. Update this element's own position
+          // too so the dragged one tracks the cursor in the same frame.
+          groupDragDeltaRef.current = { x: dxScreen, y: dyScreen };
+          onGroupDragMove?.(dxScreen, dyScreen);
+          setPosition({ x: initialPosition.x + dxScreen, y: initialPosition.y + dyScreen });
+          return;
+        }
         newPos = { x: initialPosition.x + dxScreen, y: initialPosition.y + dyScreen };
         // No clamping on position, artboard's overflow:hidden will clip.
       } else if (interactionMode === 'rotate') {
         const angle = Math.atan2(mousePosArtboard.y - elementCenter.y, mousePosArtboard.x - elementCenter.x) * (180 / Math.PI);
         const startAngle = Math.atan2(interactionStart.mouseY - elementCenter.y, interactionStart.mouseX - elementCenter.x) * (180 / Math.PI);
         newRotation = initialRotation + (angle - startAngle);
-        newRotation = Math.round(newRotation / 1) * 1; 
+        if (!freeMovement) {
+          newRotation = Math.round(newRotation / 1) * 1; 
+        }
 
       } else if (interactionMode === 'scale' && handleType && ['tl', 'tr', 'bl', 'br'].includes(handleType)) { 
         const initialDistToCenter = Math.sqrt(Math.pow(interactionStart.mouseX - elementCenter.x, 2) + Math.pow(interactionStart.mouseY - elementCenter.y, 2));
@@ -251,9 +313,37 @@ export function DraggableElement({
       setCurrentRotation(newRotation);
     };
 
-    const handleMouseUp = () => {
+    const handleMouseUp = (e: MouseEvent) => {
       if (!interactionMode || !interactionStart) return;
-      
+
+      // A click (no real movement) on a move interaction never commits; it
+      // only adjusts the selection: modifier-click toggles the element off,
+      // a plain click on a member of a multi-selection collapses to it alone.
+      const movedDistance = Math.hypot(e.clientX - interactionStart.clientX, e.clientY - interactionStart.clientY);
+      const wasClick = interactionMode === 'move' && movedDistance <= 3;
+
+      if (wasClick) {
+        if (interactionStart.clickAction === 'toggle-off') {
+          onSelect(element.id, { additive: true });
+        } else if (interactionStart.clickAction === 'collapse') {
+          onSelect(element.id, { additive: false });
+        }
+        setInteractionMode(null);
+        setInteractionStart(null);
+        document.body.style.cursor = 'default';
+        return;
+      }
+
+      if (interactionStart.groupDrag) {
+        const delta = groupDragDeltaRef.current;
+        onGroupDragEnd?.(delta.x, delta.y);
+        groupDragDeltaRef.current = { x: 0, y: 0 };
+        setInteractionMode(null);
+        setInteractionStart(null);
+        document.body.style.cursor = 'default';
+        return;
+      }
+
       // Only update if there was actually a change
       const hasPositionChanged = position.x !== element.position.x || position.y !== element.position.y;
       const hasSizeChanged = currentSize.width !== element.size.width || currentSize.height !== element.size.height;
@@ -300,7 +390,7 @@ export function DraggableElement({
         document.body.style.cursor = 'default';
       }
     };
-  }, [interactionMode, interactionStart, element, onUpdateElement, artboardZoom, boundary, position, currentSize, currentRotation, currentScale, onSelect]);
+  }, [interactionMode, interactionStart, element, onUpdateElement, artboardZoom, canvasZoom, boundary, position, currentSize, currentRotation, currentScale, onSelect, onGroupDragMove, onGroupDragEnd]);
 
 
   const displaySize = {
@@ -308,8 +398,9 @@ export function DraggableElement({
     height: currentSize.height * currentScale,
   };
 
-  // Adjust handle sizes to be visible at small scale
-  const handleVisualScale = 3 / artboardZoom; // Increase from 1 to 3 to make handles more visible
+  // Adjust handle sizes to be visible at small scale, and divide out the
+  // canvas zoom so they stay a constant on-screen size at any zoom level.
+  const handleVisualScale = 3 / (artboardZoom * canvasZoom); // Increase from 1 to 3 to make handles more visible
   const outlineThickness = Math.max(1, 3 * handleVisualScale);
 
 
@@ -360,13 +451,26 @@ export function DraggableElement({
         boxSizing: 'border-box',
       }}
       onMouseDown={(e) => {
-        if (!(e.target as HTMLElement).closest('[data-interaction-handle]')) {
-          e.stopPropagation(); // Prevent event from bubbling to artboard
+        if ((e.target as HTMLElement).closest('[data-interaction-handle]')) return;
+        if (e.button !== 0) return;
+        e.stopPropagation(); // Prevent event from bubbling to artboard
+        const additiveClick = e.shiftKey || e.ctrlKey || e.metaKey;
+        if (additiveClick) {
           if (isSelected) {
-            handleInteractionStart(e, 'move');
+            // Modifier+click on a selected element toggles it off, unless the
+            // gesture turns into a drag (Ctrl+drag = free movement).
+            handleInteractionStart(e, 'move', undefined, { clickAction: 'toggle-off' });
           } else {
-            onSelect(element.id, e); 
+            // Modifier+click on an unselected element adds it to the selection.
+            onSelect(element.id, { additive: true });
+            handleInteractionStart(e, 'move', undefined, { clickAction: 'none' });
           }
+          return;
+        }
+        if (isSelected) {
+          handleInteractionStart(e, 'move', undefined, { clickAction: 'collapse' });
+        } else {
+          onSelect(element.id, { additive: false }); 
         }
       }}
       data-element-id={element.id}

--- a/src/components/open-screenshot-generator/start/AgentStartScreen.tsx
+++ b/src/components/open-screenshot-generator/start/AgentStartScreen.tsx
@@ -21,7 +21,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Textarea } from '@/components/ui/textarea';
 import type { Project } from '@/types/artboard';
 import { AgentPlanSchema, formatPlanIssues, type AgentPlan } from '@/lib/ai/agentPlanSchema';
-import { AgentBuildError, buildProjectFromPlan, type BuildResult } from '@/lib/ai/buildProjectFromPlan';
+import { AgentBuildError, autoPlaceScreenshotsPlan, buildProjectFromPlan, type BuildResult } from '@/lib/ai/buildProjectFromPlan';
 import { AgentError, generatePlan } from '@/lib/ai/generatePlan';
 import { extractJsonCandidates } from '@/lib/ai/jsonExtract';
 import { buildCatalogArtifacts, resolveAliases, type AliasMap } from '@/lib/ai/aliasCatalog';
@@ -64,6 +64,7 @@ import { FreeProviderModePanel } from './FreeProviderModePanel';
 import { OperationTimelineDialog } from './OperationTimelineDialog';
 import { RunHistoryDialog } from './RunHistoryDialog';
 import { ScreenshotUploader } from './ScreenshotUploader';
+import { TemplateProposalPicker } from './TemplateProposalPicker';
 import { WebSessionModePanel } from './WebSessionModePanel';
 
 interface AgentStartScreenProps {
@@ -103,6 +104,9 @@ export function AgentStartScreen({
   const [stage, setStage] = useState<BridgeStage | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<BuildResult | null>(null);
+  // No-AI path: show the deterministic template proposal instead of the
+  // instruction/run sections.
+  const [proposalMode, setProposalMode] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
 
   // The finished operation behind the current error, so the alert's info icon
@@ -537,6 +541,27 @@ export function AgentStartScreen({
     }
   };
 
+  // No-AI proposal: the user picked one of the ranked templates, so build the
+  // auto-place plan and hand the project over exactly like an accepted agent
+  // plan (same onCreateProject path, no confirmation card).
+  const pickProposal = async (template: Project) => {
+    setBusy(true);
+    setError(null);
+    try {
+      const built = buildProjectFromPlan(autoPlaceScreenshotsPlan(template), screenshots, templates);
+      await onCreateProject(built.project, { nameOverride: built.project.name });
+    } catch (err) {
+      setProposalMode(false);
+      setError(
+        err instanceof AgentBuildError
+          ? err.message
+          : 'That template could not be turned into a project.'
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
   if (isLoadingTemplates) {
     return (
       <div className="space-y-4 py-4">
@@ -551,9 +576,26 @@ export function AgentStartScreen({
     <div className="space-y-6 pb-2">
       <section className="space-y-2">
         <Label className="text-sm font-bold">1. Add your app screenshots</Label>
-        <ScreenshotUploader screenshots={screenshots} onChange={setScreenshots} disabled={busy} />
+        <ScreenshotUploader
+          screenshots={screenshots}
+          onChange={setScreenshots}
+          disabled={busy}
+          onSkipAi={() => setProposalMode(true)}
+        />
       </section>
 
+      {proposalMode ? (
+        <section>
+          <TemplateProposalPicker
+            templates={templates}
+            screenshots={screenshots}
+            busy={busy}
+            onPick={(template) => void pickProposal(template)}
+            onBack={() => setProposalMode(false)}
+          />
+        </section>
+      ) : (
+        <>
       <section className="space-y-2">
         <Label htmlFor="agent-instruction" className="text-sm font-bold">
           2. Tell the agent what you want
@@ -645,6 +687,8 @@ export function AgentStartScreen({
           </TabsContent>
         </Tabs>
       </section>
+        </>
+      )}
 
       {error && (
         <Alert variant="destructive" className="relative pr-12">

--- a/src/components/open-screenshot-generator/start/ScreenshotUploader.tsx
+++ b/src/components/open-screenshot-generator/start/ScreenshotUploader.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useCallback, useRef, useState } from 'react';
-import { ImagePlus, Loader2, X } from 'lucide-react';
+import { ImagePlus, LayoutTemplate, Loader2, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { AGENT_LIMITS } from '@/lib/ai/agentPlanSchema';
@@ -11,6 +11,8 @@ interface ScreenshotUploaderProps {
   screenshots: UploadedScreenshot[];
   onChange: (screenshots: UploadedScreenshot[]) => void;
   disabled?: boolean;
+  // Opens the deterministic template proposal flow (no model involved).
+  onSkipAi?: () => void;
 }
 
 /**
@@ -18,7 +20,7 @@ interface ScreenshotUploaderProps {
  * `screenshotIndex` the agent plan refers to, and it is also the order the user
  * must attach files in when they run the manual relay steps.
  */
-export function ScreenshotUploader({ screenshots, onChange, disabled }: ScreenshotUploaderProps) {
+export function ScreenshotUploader({ screenshots, onChange, disabled, onSkipAi }: ScreenshotUploaderProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [isDragging, setIsDragging] = useState(false);
   const [isReading, setIsReading] = useState(false);
@@ -111,6 +113,22 @@ export function ScreenshotUploader({ screenshots, onChange, disabled }: Screensh
       </div>
 
       {error && <p className="text-xs text-destructive">{error}</p>}
+
+      {onSkipAi && screenshots.length > 0 && (
+        <div className="flex justify-end">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={disabled || isReading}
+            onClick={onSkipAi}
+            className="text-muted-foreground hover:text-foreground"
+          >
+            <LayoutTemplate className="mr-1.5 h-3.5 w-3.5" />
+            Skip the AI, pick a template for me
+          </Button>
+        </div>
+      )}
 
       {screenshots.length > 0 && (
         <ul className="flex flex-wrap gap-3">

--- a/src/components/open-screenshot-generator/start/TemplateProposalPicker.tsx
+++ b/src/components/open-screenshot-generator/start/TemplateProposalPicker.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import React, { useMemo } from 'react';
+import { ChevronLeft, Image as ImageIcon, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import type { Project } from '@/types/artboard';
+import {
+  buildTemplateCatalog,
+  countDeviceSlots,
+  rankTemplatesByDeviceFit,
+} from '@/lib/ai/templateCatalog';
+import type { UploadedScreenshot } from '@/lib/ai/imageUtils';
+import { withBasePath } from '@/lib/basePath';
+import { cn } from '@/lib/utils';
+
+interface TemplateProposal {
+  template: Project;
+  slots: number;
+  artboards: number;
+}
+
+interface TemplateProposalPickerProps {
+  templates: Project[];
+  screenshots: UploadedScreenshot[];
+  busy?: boolean;
+  onPick: (template: Project) => void;
+  onBack?: () => void;
+}
+
+/**
+ * The no-AI auto-design offer: rank the agent-usable templates by how well
+ * their device frames fit the screenshot batch and show the top three. The
+ * user picks one and the deterministic builder places the screenshots in its
+ * frames, so this never needs a model, a key, or a network call.
+ */
+export function TemplateProposalPicker({
+  templates,
+  screenshots,
+  busy = false,
+  onPick,
+  onBack,
+}: TemplateProposalPickerProps) {
+  const proposals = useMemo<TemplateProposal[]>(() => {
+    if (screenshots.length === 0) return [];
+    const byId = new Map(templates.map((template) => [template.id, template]));
+    // buildTemplateCatalog already filters to agent-usable templates, which
+    // excludes App Preview video templates (their frames take recordings).
+    return rankTemplatesByDeviceFit(buildTemplateCatalog(templates), screenshots.length)
+      .map((entry) => {
+        const template = byId.get(entry.id);
+        return template
+          ? { template, slots: countDeviceSlots(entry), artboards: entry.artboards.length }
+          : null;
+      })
+      .filter((proposal): proposal is TemplateProposal => proposal !== null && proposal.slots > 0)
+      .slice(0, 3);
+  }, [templates, screenshots.length]);
+
+  const count = screenshots.length;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-start gap-2">
+        {onBack && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="-ml-2 h-8 w-8 shrink-0"
+            onClick={onBack}
+            disabled={busy}
+            aria-label="Back"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+        )}
+        <div className="min-w-0 flex-1">
+          <h3 className="text-sm font-bold">Pick a template</h3>
+          <p className="text-sm text-muted-foreground">
+            {count === 1
+              ? "Pick a template, we'll place your screenshot in its device frames"
+              : `Pick a template, we'll place your ${count} screenshots in its device frames`}
+          </p>
+        </div>
+      </div>
+
+      {count > 0 && (
+        <ul className="flex flex-wrap gap-1.5">
+          {screenshots.map((shot) => (
+            <li key={shot.id}>
+              {/* Plain img: these are in-memory data URLs, not routed assets. */}
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={shot.aiDataUrl}
+                alt={shot.fileName}
+                title={shot.fileName}
+                className="h-12 w-auto rounded border"
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {count === 0 ? (
+        <p className="py-6 text-center text-sm text-muted-foreground">
+          Add at least one screenshot first.
+        </p>
+      ) : proposals.length === 0 ? (
+        <p className="py-6 text-center text-sm text-muted-foreground">
+          No templates with device frames are available.
+        </p>
+      ) : (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          {proposals.map(({ template, slots, artboards }) => {
+            const fitsAll = slots >= count;
+            const fitLine = fitsAll
+              ? count === 1
+                ? 'Fits your screenshot'
+                : `Fits all ${count} screenshots`
+              : `Places ${slots} of your ${count} screenshots`;
+            const isPlaceholder = !template.previewImage || template.previewImage.includes('placehold.co');
+            return (
+              <button
+                key={template.id}
+                type="button"
+                disabled={busy}
+                onClick={() => onPick(template)}
+                className="group flex flex-col overflow-hidden rounded-lg border bg-card text-left transition-all hover:-translate-y-0.5 hover:border-primary/50 hover:shadow-lg disabled:pointer-events-none disabled:opacity-60"
+              >
+                <div className="relative w-full overflow-hidden bg-muted" style={{ aspectRatio: '3 / 1' }}>
+                  {isPlaceholder ? (
+                    <div className="flex h-full items-center justify-center">
+                      <ImageIcon className="h-6 w-6 text-muted-foreground/40" />
+                    </div>
+                  ) : (
+                    /* Plain img: template previews are static public assets. */
+                    /* eslint-disable-next-line @next/next/no-img-element */
+                    <img
+                      src={withBasePath(template.previewImage)}
+                      alt=""
+                      className="absolute inset-0 h-full w-full object-contain transition-transform duration-300 group-hover:scale-[1.03]"
+                    />
+                  )}
+                  {busy && (
+                    <div className="absolute inset-0 flex items-center justify-center bg-background/60">
+                      <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+                    </div>
+                  )}
+                </div>
+                <div className="space-y-1 p-3">
+                  <p className="text-sm font-semibold leading-tight">{template.name}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {slots} device {slots === 1 ? 'frame' : 'frames'}, {artboards}{' '}
+                    {artboards === 1 ? 'artboard' : 'artboards'}
+                  </p>
+                  <p className={cn('text-xs', fitsAll ? 'text-muted-foreground' : 'text-amber-600 dark:text-amber-500')}>
+                    {fitLine}
+                  </p>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/contexts/ClipboardContext.tsx
+++ b/src/contexts/ClipboardContext.tsx
@@ -2,17 +2,19 @@
 import React, { createContext, useContext, useState } from 'react';
 import type { ArtboardElement } from '@/types/artboard';
 
-// Define the shape of our clipboard context
+// Define the shape of our clipboard context. Holds a SET of elements so
+// multi-select copy/paste preserves the relative arrangement; a single copy
+// is just a one-element array.
 interface ClipboardContextType {
-  clipboardItem: ArtboardElement | null;
-  copyToClipboard: (element: ArtboardElement) => void;
+  clipboardItems: ArtboardElement[];
+  copyElementsToClipboard: (elements: ArtboardElement[]) => void;
   clearClipboard: () => void;
 }
 
 // Create the context with default values
 const ClipboardContext = createContext<ClipboardContextType>({
-  clipboardItem: null,
-  copyToClipboard: () => {},
+  clipboardItems: [],
+  copyElementsToClipboard: () => {},
   clearClipboard: () => {},
 });
 
@@ -20,21 +22,21 @@ const ClipboardContext = createContext<ClipboardContextType>({
 export const useClipboard = () => useContext(ClipboardContext);
 
 export const ClipboardProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [clipboardItem, setClipboardItem] = useState<ArtboardElement | null>(null);
+  const [clipboardItems, setClipboardItems] = useState<ArtboardElement[]>([]);
 
-  // Function to copy an element to clipboard
-  const copyToClipboard = (element: ArtboardElement) => {
+  // Function to copy elements to clipboard
+  const copyElementsToClipboard = (elements: ArtboardElement[]) => {
     // Create a deep copy to avoid reference issues
-    setClipboardItem(JSON.parse(JSON.stringify(element)));
+    setClipboardItems(JSON.parse(JSON.stringify(elements)));
   };
 
   // Function to clear the clipboard
   const clearClipboard = () => {
-    setClipboardItem(null);
+    setClipboardItems([]);
   };
 
   return (
-    <ClipboardContext.Provider value={{ clipboardItem, copyToClipboard, clearClipboard }}>
+    <ClipboardContext.Provider value={{ clipboardItems, copyElementsToClipboard, clearClipboard }}>
       {children}
     </ClipboardContext.Provider>
   );

--- a/src/lib/ai/buildProjectFromPlan.ts
+++ b/src/lib/ai/buildProjectFromPlan.ts
@@ -61,6 +61,25 @@ export function buildProjectFromPlan(
     : buildNewDesign(plan, screenshots);
 }
 
+/**
+ * The no-AI "auto-design" plan: name a template, place nothing explicitly.
+ * With an empty placement list every uploaded screenshot is a leftover, so
+ * buildFromTemplate fills the template's free device frames in reading order.
+ * Shared by the start screen's skip-the-agent option and the canvas bulk-drop
+ * proposal, so both produce identical projects for the same pick.
+ */
+export function autoPlaceScreenshotsPlan(template: Project): AgentPlan {
+  return {
+    action: 'use-template',
+    projectName: '',
+    reasoning: `Built from the ${template.name} template, screenshots placed in its device frames.`,
+    templateId: template.id,
+    screenshotPlacements: [],
+    textOverrides: [],
+    newDesign: null,
+  };
+}
+
 // --- use-template ---------------------------------------------------------
 
 function buildFromTemplate(

--- a/src/lib/ai/templateCatalog.ts
+++ b/src/lib/ai/templateCatalog.ts
@@ -88,6 +88,29 @@ export function countDeviceSlots(entry: CatalogEntry): number {
   return entry.artboards.reduce((sum, ab) => sum + ab.deviceSlots.length, 0);
 }
 
+/**
+ * Deterministic "which template fits N screenshots" ranking for the no-AI
+ * proposal flow: templates that can hold every screenshot first, then by how
+ * close the slot count is to N (an exact fit beats a mostly-empty template),
+ * then by name so the order never wobbles between renders.
+ */
+export function rankTemplatesByDeviceFit(
+  entries: CatalogEntry[],
+  screenshotCount: number
+): CatalogEntry[] {
+  return [...entries].sort((a, b) => {
+    const slotsA = countDeviceSlots(a);
+    const slotsB = countDeviceSlots(b);
+    const fitsAllA = slotsA >= screenshotCount ? 0 : 1;
+    const fitsAllB = slotsB >= screenshotCount ? 0 : 1;
+    if (fitsAllA !== fitsAllB) return fitsAllA - fitsAllB;
+    const diffA = Math.abs(slotsA - screenshotCount);
+    const diffB = Math.abs(slotsB - screenshotCount);
+    if (diffA !== diffB) return diffA - diffB;
+    return a.name.localeCompare(b.name);
+  });
+}
+
 export function serializeCatalog(entries: CatalogEntry[]): string {
   const lines: string[] = [];
   for (const entry of entries) {

--- a/src/lib/elementAlignment.ts
+++ b/src/lib/elementAlignment.ts
@@ -1,0 +1,126 @@
+import type { ArtboardElement, ArtboardState, Size } from '@/types/artboard';
+
+// Alignment/distribute modes for the properties panel controls. The six align
+// modes run against the artboard for a single selection and against the
+// selection's own bounding box for a multi-selection; the distribute modes
+// need at least three elements.
+export type ElementAlignment =
+  | 'left'
+  | 'center-h'
+  | 'right'
+  | 'top'
+  | 'middle-v'
+  | 'bottom'
+  | 'distribute-h'
+  | 'distribute-v';
+
+export interface ElementBounds {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+  width: number;
+  height: number;
+}
+
+// On-canvas footprint of an element in artboard px. Text ignores element.scale
+// when it renders (fontSize drives the glyphs), so its box is the raw size;
+// every other type draws at size * scale.
+export function elementDisplaySize(element: ArtboardElement): Size {
+  if (element.type === 'text') {
+    return { width: element.size.width, height: element.size.height };
+  }
+  const scale = element.scale || 1;
+  return { width: element.size.width * scale, height: element.size.height * scale };
+}
+
+export function elementBounds(element: ArtboardElement): ElementBounds {
+  const { width, height } = elementDisplaySize(element);
+  return {
+    left: element.position.x,
+    top: element.position.y,
+    right: element.position.x + width,
+    bottom: element.position.y + height,
+    width,
+    height,
+  };
+}
+
+export function selectionBounds(elements: ArtboardElement[]): ElementBounds | null {
+  if (elements.length === 0) return null;
+  const boxes = elements.map(elementBounds);
+  const left = Math.min(...boxes.map((b) => b.left));
+  const top = Math.min(...boxes.map((b) => b.top));
+  const right = Math.max(...boxes.map((b) => b.right));
+  const bottom = Math.max(...boxes.map((b) => b.bottom));
+  return { left, top, right, bottom, width: right - left, height: bottom - top };
+}
+
+// Returns a new elements array with the given ids aligned, or null when the
+// operation would change nothing (so callers can skip a history commit).
+// Single selection aligns to the artboard bounds; multi-selection aligns to
+// the selection bounding box, with distribute available at 3+ elements.
+export function alignElementsWithinArtboard(
+  artboard: ArtboardState,
+  elementIds: string[],
+  mode: ElementAlignment
+): ArtboardElement[] | null {
+  const wanted = new Set(elementIds);
+  const members = artboard.elements.filter((el) => wanted.has(el.id));
+  if (members.length === 0) return null;
+  if ((mode === 'distribute-h' || mode === 'distribute-v') && members.length < 3) return null;
+
+  const isDistribute = mode === 'distribute-h' || mode === 'distribute-v';
+  // A single element aligns inside the artboard itself; a set aligns inside
+  // the box the set already occupies.
+  const box = members.length === 1
+    ? { left: 0, top: 0, right: artboard.size.width, bottom: artboard.size.height, width: artboard.size.width, height: artboard.size.height }
+    : selectionBounds(members);
+  if (!box) return null;
+
+  const targets = new Map<string, { x: number; y: number }>();
+
+  if (isDistribute) {
+    const horizontal = mode === 'distribute-h';
+    // Even gaps across the span the selection already covers, keeping the
+    // outermost elements pinned. Sort by position so the visual order is kept.
+    const sorted = [...members].sort((a, b) =>
+      horizontal ? a.position.x - b.position.x : a.position.y - b.position.y
+    );
+    const sizes = sorted.map(elementDisplaySize);
+    const totalSpan = horizontal ? box.width : box.height;
+    const totalSizes = sizes.reduce((sum, s) => sum + (horizontal ? s.width : s.height), 0);
+    const gap = (totalSpan - totalSizes) / (sorted.length - 1);
+    let cursor = horizontal ? box.left : box.top;
+    sorted.forEach((el, i) => {
+      const size = sizes[i];
+      targets.set(el.id, {
+        x: horizontal ? cursor : el.position.x,
+        y: horizontal ? el.position.y : cursor,
+      });
+      cursor += (horizontal ? size.width : size.height) + gap;
+    });
+  } else {
+    for (const el of members) {
+      const bounds = elementBounds(el);
+      let x = el.position.x;
+      let y = el.position.y;
+      if (mode === 'left') x = box.left;
+      else if (mode === 'center-h') x = box.left + (box.width - bounds.width) / 2;
+      else if (mode === 'right') x = box.right - bounds.width;
+      else if (mode === 'top') y = box.top;
+      else if (mode === 'middle-v') y = box.top + (box.height - bounds.height) / 2;
+      else if (mode === 'bottom') y = box.bottom - bounds.height;
+      targets.set(el.id, { x, y });
+    }
+  }
+
+  let changed = false;
+  const elements = artboard.elements.map((el) => {
+    const target = targets.get(el.id);
+    if (!target) return el;
+    if (target.x !== el.position.x || target.y !== el.position.y) changed = true;
+    return { ...el, position: target } as ArtboardElement;
+  });
+  return changed ? elements : null;
+}

--- a/src/lib/mediaStore.ts
+++ b/src/lib/mediaStore.ts
@@ -1,8 +1,9 @@
-// Blob storage for large media (screen recordings) behind the App Preview
-// video feature. Blobs live in the Dexie `media` table; elements store only
-// the row id. This module owns the id -> objectURL cache so every consumer
-// (canvas <video>, the export engine) shares one URL per asset instead of
-// leaking a new objectURL per render.
+// Blob storage for large media behind the App Preview video feature and the
+// Uploads image library. Blobs live in the Dexie `media` table; elements store
+// only the row id (recordings) or a data URL minted on use (uploaded images).
+// This module owns the id -> objectURL cache so every consumer (canvas
+// <video>, upload thumbnails, the export engine) shares one URL per asset
+// instead of leaking a new objectURL per render.
 
 import { useEffect, useState } from 'react';
 import { db } from '@/database';
@@ -12,6 +13,11 @@ export interface MediaAsset {
   blob: Blob;
   name: string;
   mimeType: string;
+  // What the blob holds. Non-indexed on purpose: Dexie only needs a version
+  // bump for schema (index) changes, and a plain field keeps old rows valid —
+  // recordings and MCP assets saved before this field existed simply have no
+  // `kind` and are treated as videos / hidden from the Uploads library.
+  kind?: 'image' | 'video';
   width?: number;
   height?: number;
   duration?: number; // seconds
@@ -55,18 +61,45 @@ export function probeVideoBlob(blob: Blob): Promise<VideoProbeResult> {
   });
 }
 
-/** Store a recording and return its media id (plus the probed metadata). */
+/** Read an image blob's natural dimensions via a throwaway <img>. */
+export function probeImageBlob(blob: Blob): Promise<{ width: number; height: number }> {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(blob);
+    const img = new Image();
+    const cleanup = () => URL.revokeObjectURL(url);
+    img.onload = () => {
+      const result = { width: img.naturalWidth, height: img.naturalHeight };
+      cleanup();
+      resolve(result);
+    };
+    img.onerror = () => {
+      cleanup();
+      reject(new Error('Could not read this image file. Use a PNG, JPEG, WebP, GIF or SVG.'));
+    };
+    img.src = url;
+  });
+}
+
+/**
+ * Store a recording or an uploaded image and return its media id (plus the
+ * probed metadata). Images are probed for dimensions only, so `duration` is 0
+ * for them; the video path is byte-for-byte the recording flow it always was.
+ */
 export async function saveMedia(
   file: Blob,
   name: string
 ): Promise<{ id: string; probe: VideoProbeResult }> {
-  const probe = await probeVideoBlob(file);
+  const isImage = file.type.startsWith('image/');
+  const probe: VideoProbeResult = isImage
+    ? { ...(await probeImageBlob(file)), duration: 0 }
+    : await probeVideoBlob(file);
   const id = `media_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
   const asset: MediaAsset = {
     id,
     blob: file,
     name,
-    mimeType: file.type || 'video/mp4',
+    mimeType: file.type || (isImage ? 'image/png' : 'video/mp4'),
+    kind: isImage ? 'image' : 'video',
     width: probe.width,
     height: probe.height,
     duration: probe.duration,
@@ -107,6 +140,44 @@ export async function deleteMedia(id: string): Promise<void> {
     urlCache.delete(id);
   }
   await db.media.delete(id);
+}
+
+/**
+ * Every user-uploaded image, newest first — the Uploads palette library.
+ * Recordings (kind 'video') and MCP agent assets (no kind, `asset_` ids) are
+ * excluded: neither is user-managed library content.
+ */
+export async function listUploadedImages(): Promise<MediaAsset[]> {
+  const rows = await db.media.toArray();
+  return rows
+    .filter((row) => row.kind === 'image')
+    .sort(
+      (a, b) =>
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+    );
+}
+
+/** Rename a stored asset (the Uploads panel's inline rename). */
+export async function renameMedia(id: string, name: string): Promise<void> {
+  await db.media.update(id, { name });
+}
+
+/**
+ * Read a stored blob out as a data URL, or null when the row is gone.
+ * Uploads mint image element sources this way so the project row keeps
+ * serializing to plain data URLs; callers should cache the result per
+ * interaction rather than hold one per tile (a data URL duplicates the blob
+ * in memory as a base64 string).
+ */
+export async function getMediaDataUrl(id: string): Promise<string | null> {
+  const asset = await db.media.get(id);
+  if (!asset) return null;
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(new Error('Could not read the stored image.'));
+    reader.readAsDataURL(asset.blob);
+  });
 }
 
 /**


### PR DESCRIPTION
> **STACKED DRAFT** — this branch builds on #10 and #11 (multi-select/alignment and export formats). Its diff against `main` will stay noisy until those merge; I will rebase it onto `main` once they land, and mark it ready.

## What
1. **Uploads library (closes #5)** — 'Your uploads' category in the element palette's Images tab: multi-file upload (input + drag-into-panel), tiles with thumbnails, drag/click to place on canvas, inline rename, delete, empty state. Images are stored as blobs in the existing Dexie `media` table (new non-indexed `kind: 'image' | 'video'` discriminator — no schema/index change, no version bump); recordings keep their flow untouched.
2. **OS file drops onto the canvas** — dropping image files from the OS onto an artboard adds them as image elements (natural size, drop point, cascade for multiples, clamped); dropping directly on a device frame fills that frame's screenshot instead. One history entry per drop.
3. **Bulk drop → template proposal (closes #3)** — 'Skip the AI, pick a template for me' on the start screen, and dropping 2+ files on an empty canvas, rank agent-usable templates by device-slot fit (`countDeviceSlots`) and present the top 3 as cards; picking one builds the project deterministically via the existing `buildFromTemplate` (no LLM). Handoff uses the same `onCreateProject` path as the AI agent.

## Verification
- `npm run typecheck`: pre-existing baseline only
- `npm run build`: passes
- Headless-browser: 29/29 checks (library CRUD + persistence, tile→canvas drag, 2-file artboard drop, frame drop, proposal flow end-to-end with Dexie-level assertions)