### PR TITLE
Keep uploaded screenshots in macOS PNG exports

### DIFF
--- a/src/components/open-screenshot-generator/OpenScreenshotGeneratorLayout.tsx
+++ b/src/components/open-screenshot-generator/OpenScreenshotGeneratorLayout.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useState, useEffect, useLayoutEffect, useCallback, useMemo, useRef, useDeferredValue } from 'react';
 import { toPng } from 'html-to-image';
+import { withBlobImagesInlined } from '@/lib/inlineBlobImages';
 import { preloadGoogleFonts } from '@/services/fontService';
 import { loadCustomFonts, useCustomFonts } from '@/services/customFonts';
 import { isTauri, sanitizeFileName, saveBlobToDisk, saveBlobToPath, saveDataUrlToDisk, saveDataUrlToPath, pickExportDirectory, openExternal, fetchWebviewCrashInfo } from '@/lib/desktop';
@@ -2904,7 +2905,9 @@ export function OpenScreenshotGeneratorLayout() {
     // the whole async capture, briefly overlapping neighboring boards on
     // screen, which is the background-bleed half of the issue #19 glitch.
     const { backgroundColor, backgroundImage } = artboardBackground(artboard);
-    return await toPng(artboardElement, {
+    // WKWebView cannot reliably fetch(blob:) during html-to-image's embed
+    // pass, so uploaded screenshots must be data URLs for this capture.
+    return await withBlobImagesInlined(artboardElement, () => toPng(artboardElement, {
       width: artboard.size.width,
       height: artboard.size.height,
       backgroundColor,
@@ -2927,7 +2930,7 @@ export function OpenScreenshotGeneratorLayout() {
         height: `${artboard.size.height}px`,
         backgroundImage,
       }
-    });
+    }));
   };
 
   const captureArtboards = async (
@@ -5118,7 +5121,7 @@ const generateRandomProjectName = (): string => {
     // Unscale via the clone (the `style` option), never the live node: see
     // captureArtboardDataUrl for the on-screen overlap this used to cause.
     const { backgroundColor, backgroundImage } = artboardBackground(board);
-    const dataUrl = await toPng(node, {
+    const dataUrl = await withBlobImagesInlined(node, () => toPng(node, {
       width: board.size.width,
       height: board.size.height,
       backgroundColor,
@@ -5137,7 +5140,7 @@ const generateRandomProjectName = (): string => {
         height: `${board.size.height}px`,
         backgroundImage,
       },
-    });
+    }));
 
     const base64 = dataUrl.replace(/^data:image\/png;base64,/, '');
     const result: McpExportResult = {

--- a/src/components/open-screenshot-generator/elements/DeviceFrameElement.tsx
+++ b/src/components/open-screenshot-generator/elements/DeviceFrameElement.tsx
@@ -43,8 +43,13 @@ export function DeviceFrameElement({ element, onUpdate, isSelected }: DeviceFram
   const screenshot = useImageSrc(element.screenshotSrc);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [uploadTarget, setUploadTarget] = useState<'customFrame' | 'screenshot' | null>(null);
-  // Add a state to track if high-quality rendering should be used
   const [useHighQualityRendering, setUseHighQualityRendering] = useState(true);
+  // Fade-in used to set img.style.opacity in onLoad. A later React render
+  // writes opacity: 0 back from the style prop, and onLoad does not fire
+  // again, so PNG export (html-to-image copies computed styles) captured an
+  // invisible screenshot. Track which src has loaded instead of mutating the DOM.
+  const [loadedScreenshotSrc, setLoadedScreenshotSrc] = useState<string | null>(null);
+  const screenshotReady = Boolean(screenshot && loadedScreenshotSrc === screenshot);
 
   // Uploads land in the Dexie media table and the element keeps only an
   // asset:<id> reference — inlining the file as a data URL made every undo
@@ -443,7 +448,7 @@ export function DeviceFrameElement({ element, onUpdate, isSelected }: DeviceFram
                   alt={`${element.deviceType} screenshot`}
                   style={{
                     cursor: 'inherit',
-                    opacity: 0,
+                    opacity: screenshotReady ? 1 : 0,
                     width: '100%',
                     height: '100%',
                     objectFit: element.screenshotObjectFit || "cover",
@@ -451,7 +456,7 @@ export function DeviceFrameElement({ element, onUpdate, isSelected }: DeviceFram
                     top: 0,
                     left: 0,
                   }}
-                  onLoad={e => { (e.currentTarget as HTMLImageElement).style.opacity = '1'; }}
+                  onLoad={() => setLoadedScreenshotSrc(screenshot)}
                   data-ai-hint="app interface mobile"
                   draggable={false}
                 />

--- a/src/lib/inlineBlobImages.ts
+++ b/src/lib/inlineBlobImages.ts
@@ -1,0 +1,87 @@
+// html-to-image re-fetches every <img> src while building the SVG clone.
+// Uploaded screenshots live as blob: object URLs (issue #19 media work).
+// Chrome can fetch those; WKWebView in the macOS desktop app often cannot,
+// and the failure is swallowed into an empty placeholder. The live <img>
+// still paints, so the canvas looks right and the PNG comes out with a
+// hollow device frame. Inline the bytes as data URLs for the capture only.
+
+import { blobForObjectUrl } from '@/lib/mediaStore';
+
+function readBlobAsDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result));
+    reader.onerror = () => reject(new Error('Could not read a blob image for export.'));
+    reader.readAsDataURL(blob);
+  });
+}
+
+async function blobFromSrc(src: string): Promise<Blob | null> {
+  const cached = blobForObjectUrl(src);
+  if (cached) return cached;
+  try {
+    const res = await fetch(src);
+    if (!res.ok) return null;
+    return await res.blob();
+  } catch {
+    return null;
+  }
+}
+
+/** Last resort when fetch(blob:) fails and we have no cached Blob: the live
+ *  <img> is already decoded, so draw it. Same-origin blob: images are not tainted. */
+function dataUrlFromDecodedImage(img: HTMLImageElement): string | null {
+  if (!img.complete || img.naturalWidth < 1 || img.naturalHeight < 1) return null;
+  try {
+    const canvas = document.createElement('canvas');
+    canvas.width = img.naturalWidth;
+    canvas.height = img.naturalHeight;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return null;
+    ctx.drawImage(img, 0, 0);
+    return canvas.toDataURL('image/png');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Temporarily replace blob: image srcs under `root` with data URLs, run
+ * `work` (the html-to-image capture), then put the object URLs back.
+ */
+export async function withBlobImagesInlined<T>(
+  root: HTMLElement,
+  work: () => Promise<T>
+): Promise<T> {
+  const images = Array.from(root.querySelectorAll('img'));
+  const restore: Array<() => void> = [];
+
+  await Promise.all(
+    images.map(async (img) => {
+      const src = img.currentSrc || img.src;
+      if (!src.startsWith('blob:')) return;
+      let dataUrl: string | null = null;
+      const blob = await blobFromSrc(src);
+      if (blob) {
+        try {
+          dataUrl = await readBlobAsDataUrl(blob);
+        } catch {
+          dataUrl = null;
+        }
+      }
+      if (!dataUrl) dataUrl = dataUrlFromDecodedImage(img);
+      if (!dataUrl) return;
+      const previous = img.getAttribute('src') ?? img.src;
+      img.src = dataUrl;
+      restore.push(() => {
+        img.src = previous;
+      });
+    })
+  );
+
+  try {
+    return await work();
+  } finally {
+    for (const undo of restore) undo();
+  }
+}

--- a/src/lib/mediaStore.ts
+++ b/src/lib/mediaStore.ts
@@ -45,6 +45,15 @@ export interface VideoProbeResult {
 }
 
 const urlCache = new Map<string, string>();
+// Object URL -> original Blob. html-to-image re-fetches every <img> src during
+// PNG export; WKWebView's fetch(blob:) often fails silently, so export needs
+// the Blob itself to inline a data URL without going back through fetch.
+const blobByObjectUrl = new Map<string, Blob>();
+
+/** Blob that backs a session object URL minted by getMediaUrl, if we still have it. */
+export function blobForObjectUrl(url: string): Blob | undefined {
+  return blobByObjectUrl.get(url);
+}
 
 /** Read a video blob's dimensions and duration via a throwaway <video>. */
 export function probeVideoBlob(blob: Blob): Promise<VideoProbeResult> {
@@ -117,6 +126,7 @@ export async function getMediaUrl(id: string): Promise<string | null> {
     return winner;
   }
   urlCache.set(id, url);
+  blobByObjectUrl.set(url, asset.blob);
   return url;
 }
 
@@ -125,6 +135,7 @@ export async function deleteMedia(id: string): Promise<void> {
   if (url) {
     URL.revokeObjectURL(url);
     urlCache.delete(id);
+    blobByObjectUrl.delete(url);
   }
   await db.media.delete(id);
 }

--- a/src/lib/video/videoExport.ts
+++ b/src/lib/video/videoExport.ts
@@ -12,6 +12,7 @@
 
 import { toPng, getFontEmbedCSS } from 'html-to-image';
 import { Muxer, ArrayBufferTarget } from 'mp4-muxer';
+import { withBlobImagesInlined } from '@/lib/inlineBlobImages';
 import type {
   ArtboardState,
   ArtboardElement,
@@ -219,7 +220,7 @@ async function captureSprite(
   // CLONE. The live node used to be moved to the pad origin with its transform
   // stripped for the whole async capture, which visibly displaced the element
   // on the canvas per sprite and left it misplaced if a capture threw.
-  const dataUrl = await toPng(node, {
+  const dataUrl = await withBlobImagesInlined(node, () => toPng(node, {
     width: Math.max(1, Math.round(boxW + pad * 2)),
     height: Math.max(1, Math.round(boxH + pad * 2)),
     pixelRatio: 1,
@@ -233,7 +234,7 @@ async function captureSprite(
       top: `${pad}px`,
       transform: 'none',
     },
-  });
+  }));
   return { image: await dataUrlToImage(dataUrl), pad };
 }
 


### PR DESCRIPTION
## Summary
- On the macOS desktop app, uploaded screenshots showed correctly on the canvas but disappeared from PNG exports (empty device frames).
- `html-to-image` re-fetches `blob:` screenshot URLs, and WKWebView often fails that fetch silently. Export now inlines those images as data URLs first.
- Flat device frames also kept screenshot fade-in in React state, so a later render could not reset opacity to 0 and capture an invisible image.

## Test plan
- [ ] In the macOS desktop app, open a template with 2D device frames and upload your own screenshots.
- [ ] Confirm the screenshots are visible on the canvas.
- [ ] Export artboards as PNG and confirm each mockup still contains the uploaded screenshot.
- [ ] Repeat a PNG export in the browser (Chrome) to confirm web export is unchanged.


Made with [Cursor](https://cursor.com)